### PR TITLE
Code-review fixes: bug fixes, security hardening, infra polish

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+.gitignore
+.dockerignore
+.DS_Store
+__pycache__
+*.pyc
+test/
+reports/result*
+reports/graph.html
+reports/reports.zip
+LICENSE.md
+SECURITY.md
+README.md

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -30,16 +30,17 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     name: Scan
     runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    if: (github.actor != 'dependabot[bot]')
     steps:
       # Checkout project source
       - uses: actions/checkout@v4
 
       # Scan code using project's configuration on https://semgrep.dev/manage
-      - uses: returntocorp/semgrep-action@fcd5ab7459e8d91cb1777481980d1b18b4fc6735
-        with:
-          publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}
-          publishDeployment: ${{ secrets.SEMGREP_DEPLOYMENT_ID }}
-          generateSarif: "1"
+      - run: semgrep ci --sarif --output=semgrep.sarif
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
 
       # Upload SARIF file generated in previous step
       - name: Upload SARIF file

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dt-report-generator (dtrg) <img width="30" src="./static/icon.svg"/>
 ## Main information
-Tool for create reports from [Dependency Track](https://dependencytrack.org/) in Word (.docx) и Excel (.xlsx) formats.\
+Tool for create reports from [Dependency Track](https://dependencytrack.org/) in Word (.docx) and Excel (.xlsx) formats.\
 More information about tool and how to use it can be found in the articles on habr [1](https://habr.com/ru/articles/860536/), [2](https://habr.com/ru/articles/900276/) (rus).
 ## Getting started
 ### Installation and start
@@ -51,7 +51,7 @@ All environment variables:
 * DTRG_URL - DT address
 * DTRG_TOKEN - DT API key
 * DTRG_PORT - dtrg port
-* DTRG_DEGUB - dtrg (Flask) debug mode
+* DTRG_DEBUG - dtrg (Flask) debug mode
 * CVEPAAS_URL - [CVE-PaaS](https://github.com/denimoll/CVE-PaaS) address
 ## Roadmap
 Planned functionality:

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ All environment variables:
 * DTRG_TOKEN - DT API key
 * DTRG_PORT - dtrg port
 * DTRG_DEBUG - dtrg (Flask) debug mode
+* DTRG_VERIFY_TLS - verify TLS certificate of DT and CVE-PaaS (default: true; set to false only for self-signed test instances)
 * CVEPAAS_URL - [CVE-PaaS](https://github.com/denimoll/CVE-PaaS) address
 ## Roadmap
 Planned functionality:

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ All environment variables:
 * DTRG_DEBUG - dtrg (Flask) debug mode. Refuses to start when combined with a non-loopback DTRG_HOST unless DTRG_DEBUG_ALLOW_REMOTE=true is set, because the Werkzeug debugger can be used for remote code execution.
 * DTRG_DEBUG_ALLOW_REMOTE - explicit override that allows DTRG_DEBUG=true together with a non-loopback DTRG_HOST. Use only in trusted networks.
 * DTRG_VERIFY_TLS - verify TLS certificate of DT and CVE-PaaS (default: true; set to false only for self-signed test instances)
+* DTRG_HTTP_TIMEOUT - timeout in seconds for outbound HTTP calls to DT and CVE-PaaS (default: 120)
 * DTRG_SECRET_KEY - Flask secret key. Set a stable value when running multiple workers or behind a reverse proxy so CSRF tokens stay valid across restarts. If unset, a random key is generated on each start.
 * CVEPAAS_URL - [CVE-PaaS](https://github.com/denimoll/CVE-PaaS) address
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -72,3 +72,4 @@ Planned functionality:
 - [ ] *Optimization*. Add a Database for fast search.
 - [ ] *Specification*. Add a swagger / more info for API Endpoint like parameters in and out.
 - [ ] *Graph*. Manage deep of graph and add info to report about graph_level.
+- [ ] *Tests*. Add smoke/unit tests (validators, severity merge, graph traversal) so regressions are caught before release.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ All environment variables:
 * DTRG_URL - DT address
 * DTRG_TOKEN - DT API key
 * DTRG_PORT - dtrg port
-* DTRG_DEBUG - dtrg (Flask) debug mode
+* DTRG_HOST - bind address (default: 0.0.0.0)
+* DTRG_DEBUG - dtrg (Flask) debug mode. Refuses to start when combined with a non-loopback DTRG_HOST unless DTRG_DEBUG_ALLOW_REMOTE=true is set, because the Werkzeug debugger can be used for remote code execution.
+* DTRG_DEBUG_ALLOW_REMOTE - explicit override that allows DTRG_DEBUG=true together with a non-loopback DTRG_HOST. Use only in trusted networks.
 * DTRG_VERIFY_TLS - verify TLS certificate of DT and CVE-PaaS (default: true; set to false only for self-signed test instances)
 * DTRG_SECRET_KEY - Flask secret key. Set a stable value when running multiple workers or behind a reverse proxy so CSRF tokens stay valid across restarts. If unset, a random key is generated on each start.
 * CVEPAAS_URL - [CVE-PaaS](https://github.com/denimoll/CVE-PaaS) address

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ All environment variables:
 * DTRG_PORT - dtrg port
 * DTRG_DEBUG - dtrg (Flask) debug mode
 * DTRG_VERIFY_TLS - verify TLS certificate of DT and CVE-PaaS (default: true; set to false only for self-signed test instances)
+* DTRG_SECRET_KEY - Flask secret key. Set a stable value when running multiple workers or behind a reverse proxy so CSRF tokens stay valid across restarts. If unset, a random key is generated on each start.
 * CVEPAAS_URL - [CVE-PaaS](https://github.com/denimoll/CVE-PaaS) address
 ## Roadmap
 Planned functionality:

--- a/app.py
+++ b/app.py
@@ -115,35 +115,9 @@ def create_graph(components):
     logger.info("Generating graph from components")
     graph = get_graph(components)
     if graph:
+        rendered = render_template("graph.html", graph=graph)
         with open("reports/graph.html", "w", encoding="utf-8") as f:
-            f.write(
-                f"""<html>
-                <head><link rel="stylesheet" href="resource://content-accessible/plaintext.css">
-                <style>
-                    pre {{
-                        line-height: 1.4;
-                    }}
-                    .pkg {{
-                    color: #333;
-                    }}
-                    .vuln {{
-                    font-weight: bold;
-                    }}
-                    .vuln-critical {{
-                    color: #b30000;
-                    }}
-                    .vuln-high {{
-                    color: #d9534f;
-                    }}
-                    .vuln-medium {{
-                    color: #f0ad4e;
-                    }}
-                    .vuln-low {{
-                    color: #5bc0de;
-                    }}
-                </style>
-                </head><body><pre>{graph}</pre></body>
-                </html>""")
+            f.write(rendered)
         logger.info("Graph HTML saved successfully")
         return True
     logger.warning("Graph data was empty; skipping HTML generation")

--- a/app.py
+++ b/app.py
@@ -70,13 +70,18 @@ def create_zip(with_graph=False):
         flash(str(e), "danger")
         return False
 
+def _redact(form_data):
+    """ Drop secret-bearing fields from form data before logging """
+    return {k: ("<redacted>" if k in {"token", "csrf_token"} else v)
+            for k, v in form_data.items()}
+
 @app.route("/reports/get_report", methods=["POST"])
 def get_report():
     """ API Endpoint /reports/get_report """
     logger.info("Received request to generate report")
     clear_tmp_files()
     data = request.form.to_dict(flat=False)
-    logger.debug(f"Form data received: {data}")
+    logger.debug(f"Form data received: {_redact(data)}")
     report, components = create_report(data)
     with_graph = create_graph(components) if components else False
     if isinstance(report, str) and create_zip(with_graph):

--- a/app.py
+++ b/app.py
@@ -57,22 +57,18 @@ def clear_tmp_files():
 def create_zip(with_graph=False):
     """ Additional function for create final archive with all materials """
     logger.info("Creating ZIP archive with report files")
-    os.chdir("reports/")
     try:
-        zipf = zipfile.ZipFile("reports.zip", "w", zipfile.ZIP_DEFLATED)
-        for file in ["result.docx", "result.xlsx"]:
-            zipf.write(file)
-        if with_graph:
-            zipf.write("graph.html")
-        zipf.close()
+        with zipfile.ZipFile("reports/reports.zip", "w", zipfile.ZIP_DEFLATED) as zipf:
+            for file in ["result.docx", "result.xlsx"]:
+                zipf.write(os.path.join("reports", file), arcname=file)
+            if with_graph:
+                zipf.write("reports/graph.html", arcname="graph.html")
         logger.info("ZIP archive created successfully")
         return True
-    except Exception as e:
+    except OSError as e:
         logger.error(f"Error while creating ZIP: {e}")
         flash(str(e), "danger")
         return False
-    finally:
-        os.chdir("..")
 
 @app.route("/reports/get_report", methods=["POST"])
 def get_report():

--- a/app.py
+++ b/app.py
@@ -115,7 +115,7 @@ def create_graph(components):
     logger.info("Generating graph from components")
     graph = get_graph(components)
     if graph:
-        with open ("reports/graph.html", "w", encoding="utf-8") as f:
+        with open("reports/graph.html", "w", encoding="utf-8") as f:
             f.write(
                 f"""<html>
                 <head><link rel="stylesheet" href="resource://content-accessible/plaintext.css">

--- a/app.py
+++ b/app.py
@@ -127,10 +127,23 @@ def create_graph(components):
 if __name__ == "__main__":
     debug_mode = os.getenv("DTRG_DEBUG", "False").lower() in ["true", "1", "t"]
     port = int(os.getenv("DTRG_PORT", "5000"))
+    host = os.getenv("DTRG_HOST", "0.0.0.0")
+    allow_remote_debug = os.getenv("DTRG_DEBUG_ALLOW_REMOTE", "False").lower() in [
+        "true", "1", "t"
+    ]
+
+    # Werkzeug debugger exposes a remote code execution path via the PIN
+    # console. Refuse to combine debug mode with a non-loopback bind unless
+    # operators explicitly opt in.
+    if debug_mode and host not in ("127.0.0.1", "localhost") and not allow_remote_debug:
+        raise SystemExit(
+            "DTRG_DEBUG=true is unsafe with a non-loopback DTRG_HOST. "
+            "Set DTRG_HOST=127.0.0.1 or DTRG_DEBUG_ALLOW_REMOTE=true to confirm."
+        )
 
     # Set logging level based on debug mode
     log_level = logging.DEBUG if debug_mode else logging.INFO
     logging.getLogger().setLevel(log_level)
-    logger.info(f"Starting app on port {port} with debug={debug_mode}")
+    logger.info(f"Starting app on {host}:{port} with debug={debug_mode}")
 
-    app.run(host="0.0.0.0", port=port, debug=debug_mode)
+    app.run(host=host, port=port, debug=debug_mode)

--- a/app.py
+++ b/app.py
@@ -29,7 +29,7 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 app = Flask(__name__)
-app.config["SECRET_KEY"] = secrets.token_hex(16)
+app.config["SECRET_KEY"] = os.getenv("DTRG_SECRET_KEY") or secrets.token_hex(16)
 bootstrap = Bootstrap5(app)
 
 

--- a/backend/dependency_graph.py
+++ b/backend/dependency_graph.py
@@ -24,18 +24,25 @@ def get_graph(components, depth=3):
     # create Tree root
     tree = Node("Application")
 
-    def update_direct_dependencies(dependencies, depth):
+    def update_direct_dependencies(dependencies, depth, visited=None):
         """ Recursively expand all nested dependencies """
         logger.debug(f"Expanding dependencies at depth={depth}")
+        if visited is None:
+            visited = set()
         deps_deps = []
         copy_dependencies = copy.deepcopy(dependencies)
 
         for num, dependency in enumerate(copy_dependencies):
-            for dep in dependency.get("dependencies"):
+            for dep in dependency.get("dependencies") or []:
+                if dep in visited:
+                    continue
+                visited.add(dep)
                 dep_value = copy.deepcopy(components.get(dep))
+                if dep_value is None:
+                    continue
                 deps_deps.append(dep_value)
                 dependencies[num]["dependencies"] = update_direct_dependencies(
-                    copy.deepcopy(deps_deps), depth-1) if depth and deps_deps else []
+                    copy.deepcopy(deps_deps), depth-1, visited) if depth and deps_deps else []
             deps_deps = []
         return dependencies
 

--- a/backend/param_validators.py
+++ b/backend/param_validators.py
@@ -41,7 +41,7 @@ def check_token(token: str, url: str) -> dict[str, str]:
 
 def check_project(project: str) -> str:
     """ Check existence project """
-    logger.debug("Validating project: {project}")
+    logger.debug(f"Validating project: {project}")
     if not project:
         logger.error("Project not set")
         raise ValueError("Project not set")

--- a/backend/param_validators.py
+++ b/backend/param_validators.py
@@ -1,12 +1,21 @@
 """ Module for validate and formatted parameters """
 import logging
+import os
 
 import requests
 import urllib3
 import validators
 
-urllib3.disable_warnings()
 logger = logging.getLogger(__name__)
+
+
+def verify_tls() -> bool:
+    """ Whether outbound HTTPS calls should verify the TLS certificate """
+    return os.getenv("DTRG_VERIFY_TLS", "true").lower() in ["true", "1", "t"]
+
+
+if not verify_tls():
+    urllib3.disable_warnings()
 
 
 def check_format_url(url: str) -> str:
@@ -29,7 +38,7 @@ def check_token(token: str, url: str) -> dict[str, str]:
         "X-Api-Key": token
     }
     try:
-        res = requests.get(url+"project", headers=headers, verify=False, timeout=100)
+        res = requests.get(url+"project", headers=headers, verify=verify_tls(), timeout=100)
         if res.status_code != 200:
             logger.warning(f"Connection failed. Status: {res.status_code}, Response: {res.text}")
             raise ConnectionError("Something wrong with connection. Check your parameters")

--- a/backend/param_validators.py
+++ b/backend/param_validators.py
@@ -14,6 +14,14 @@ def verify_tls() -> bool:
     return os.getenv("DTRG_VERIFY_TLS", "true").lower() in ["true", "1", "t"]
 
 
+def http_timeout() -> int:
+    """ Timeout in seconds for outbound HTTP calls to DT and CVE-PaaS """
+    try:
+        return int(os.getenv("DTRG_HTTP_TIMEOUT", "120"))
+    except ValueError:
+        return 120
+
+
 if not verify_tls():
     urllib3.disable_warnings()
 
@@ -38,7 +46,8 @@ def check_token(token: str, url: str) -> dict[str, str]:
         "X-Api-Key": token
     }
     try:
-        res = requests.get(url+"project", headers=headers, verify=verify_tls(), timeout=100)
+        res = requests.get(url+"project", headers=headers,
+                           verify=verify_tls(), timeout=http_timeout())
         if res.status_code != 200:
             logger.warning(f"Connection failed. Status: {res.status_code}, Response: {res.text}")
             raise ConnectionError("Something wrong with connection. Check your parameters")

--- a/backend/projects.py
+++ b/backend/projects.py
@@ -18,11 +18,7 @@ def get_projects(url, token):
         
         # validate parameters
         url = check_format_url(url)
-        if not isinstance(url, str):
-            return url
         headers = check_token(token, url)
-        if not isinstance(headers, dict):
-            return headers
         
         endpoint = (
             f"{url}project?excludeInactive=true&onlyRoot=false&searchText=&"

--- a/backend/projects.py
+++ b/backend/projects.py
@@ -4,7 +4,7 @@ import logging
 
 import requests
 
-from backend.param_validators import check_format_url, check_token, verify_tls
+from backend.param_validators import check_format_url, check_token, http_timeout, verify_tls
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +26,7 @@ def get_projects(url, token):
 
         # get projects
         res = requests.get(endpoint,
-            headers=headers, verify=verify_tls(), timeout=1000)
+            headers=headers, verify=verify_tls(), timeout=http_timeout())
         logger.debug(f"Successfully fetched projects, status code: {res.status_code}")
         return res.text
     except requests.RequestException as e:

--- a/backend/projects.py
+++ b/backend/projects.py
@@ -3,11 +3,9 @@
 import logging
 
 import requests
-import urllib3
 
-from backend.param_validators import check_format_url, check_token
+from backend.param_validators import check_format_url, check_token, verify_tls
 
-urllib3.disable_warnings()
 logger = logging.getLogger(__name__)
 
 
@@ -28,7 +26,7 @@ def get_projects(url, token):
 
         # get projects
         res = requests.get(endpoint,
-            headers=headers, verify=False, timeout=1000)
+            headers=headers, verify=verify_tls(), timeout=1000)
         logger.debug(f"Successfully fetched projects, status code: {res.status_code}")
         return res.text
     except requests.RequestException as e:

--- a/backend/projects.py
+++ b/backend/projects.py
@@ -28,7 +28,7 @@ def get_projects(url, token):
             f"{url}project?excludeInactive=true&onlyRoot=false&searchText=&"
             "sortName=lastBomImport&sortOrder=desc&pageSize=99999&pageNumber=1"
         )
-        logger.debug("Sending request to: {endpoint}")
+        logger.debug(f"Sending request to: {endpoint}")
 
         # get projects
         res = requests.get(endpoint,

--- a/backend/reports.py
+++ b/backend/reports.py
@@ -29,7 +29,7 @@ def get_severity(severities):
         "high": 3,
         "critical": 4
     }
-    level = max(list(severity[x] for x in severities))
+    level = max(severity.get((x or "").lower(), 0) for x in severities)
     return level, [key for key, val in severity.items() if val == level][0]
 
 

--- a/backend/reports.py
+++ b/backend/reports.py
@@ -130,7 +130,9 @@ def create_report(config):
                 if "cve" in vuln_id.lower():
                     vuln_link = "https://nvd.nist.gov/vuln/detail/"+vuln_id
                     vuln_word_link.add(vuln_id, url_id=doc.build_url_id(vuln_link))
-                    cve_id = vuln_id
+                    # only canonical CVE-YYYY-NNNN ids may flow into the CVE-PaaS URL
+                    cve_id = vuln_id if re.fullmatch(r"CVE-\d{4}-\d{4,7}",
+                                                     vuln_id, re.IGNORECASE) else ""
                 elif "ghsa" in vuln_id.lower():
                     vuln_link = "https://github.com/advisories/"+vuln_id
                     vuln_word_link.add(vuln_id, url_id=doc.build_url_id(vuln_link))

--- a/backend/reports.py
+++ b/backend/reports.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import re
 from datetime import datetime
 
 import requests
@@ -54,7 +55,11 @@ def create_report(config):
         if not isinstance(headers, dict):
             # can be error from backend.param_validators
             raise headers # pylint: disable=raising-bad-type
-        project = check_project(config.get("project")[0].split("(")[1].split(")")[0])
+        project_raw = config.get("project")[0]
+        project_match = re.search(r"\(([^()]+)\)\s*$", project_raw)
+        if not project_match:
+            raise ValueError("Project value must end with (uuid)")
+        project = check_project(project_match.group(1))
         if not isinstance(project, str):
             raise project
 

--- a/backend/reports.py
+++ b/backend/reports.py
@@ -128,11 +128,11 @@ def create_report(config):
             for component in vuln.get("affects"):
                 vuln_id = vuln.get("id")
                 vuln_word_link = RichText()
-                if vuln_id.lower().find("cve") != -1:
+                if "cve" in vuln_id.lower():
                     vuln_link = "https://nvd.nist.gov/vuln/detail/"+vuln_id
                     vuln_word_link.add(vuln_id, url_id=doc.build_url_id(vuln_link))
                     cve_id = vuln_id
-                elif vuln_id.lower().find("ghsa") != -1:
+                elif "ghsa" in vuln_id.lower():
                     vuln_link = "https://github.com/advisories/"+vuln_id
                     vuln_word_link.add(vuln_id, url_id=doc.build_url_id(vuln_link))
 # https://docs.github.com/en/rest/security-advisories/global-advisories?apiVersion=2022-11-28

--- a/backend/reports.py
+++ b/backend/reports.py
@@ -11,7 +11,13 @@ from docxtpl import DocxTemplate, RichText
 from openpyxl import load_workbook
 from openpyxl.styles import Alignment
 
-from backend.param_validators import check_format_url, check_project, check_token, verify_tls
+from backend.param_validators import (
+    check_format_url,
+    check_project,
+    check_token,
+    http_timeout,
+    verify_tls,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +62,7 @@ def create_report(config):
        # get common info about project
         logger.info("Fetching project metadata")
         res = requests.get(url+"project/"+project, headers=headers,
-                           verify=verify_tls(), timeout=1000)
+                           verify=verify_tls(), timeout=http_timeout())
         res.raise_for_status()
         text = res.json()
         project_name = RichText()
@@ -85,7 +91,7 @@ def create_report(config):
         logger.info("Fetching SBOM with vulnerabilities")
         res = requests.get(url+"bom/cyclonedx/project/"+project
                            +"?format=json&variant=withVulnerabilities&download=true",
-                           headers=headers, verify=verify_tls(), timeout=10000)
+                           headers=headers, verify=verify_tls(), timeout=http_timeout())
         res.raise_for_status()
         text = res.json()
         vulnerabilities = text.get("vulnerabilities") or []
@@ -98,7 +104,7 @@ def create_report(config):
         # get components
         res = requests.get(url+"component/project/"+project+
             "?searchText=&pageSize=99999&pageNumber=1",
-            headers=headers, verify=verify_tls(), timeout=10000)
+            headers=headers, verify=verify_tls(), timeout=http_timeout())
         res.raise_for_status()
         for component in res.json():
             try:
@@ -145,7 +151,7 @@ def create_report(config):
                 severity_level, severity = get_severity(list(x.get("severity")
                                                              for x in vuln.get("ratings")))
                 cve_paas = json.loads(requests.get(os.getenv("CVEPAAS_URL")+"/get_info/"+cve_id,
-                  verify=verify_tls(), timeout=100).text) \
+                  verify=verify_tls(), timeout=http_timeout()).text) \
                   if os.getenv("CVEPAAS_URL") and cve_id else {}
                 add_info = []
                 if cve_paas.get("Priority") and cve_paas.get("Priority").lower() == "critical":

--- a/backend/reports.py
+++ b/backend/reports.py
@@ -7,14 +7,12 @@ import re
 from datetime import datetime
 
 import requests
-import urllib3
 from docxtpl import DocxTemplate, RichText
 from openpyxl import load_workbook
 from openpyxl.styles import Alignment
 
-from backend.param_validators import check_format_url, check_project, check_token
+from backend.param_validators import check_format_url, check_project, check_token, verify_tls
 
-urllib3.disable_warnings()
 logger = logging.getLogger(__name__)
 
 
@@ -57,7 +55,8 @@ def create_report(config):
 
        # get common info about project
         logger.info("Fetching project metadata")
-        res = requests.get(url+"project/"+project, headers=headers, verify=False, timeout=1000)
+        res = requests.get(url+"project/"+project, headers=headers,
+                           verify=verify_tls(), timeout=1000)
         res.raise_for_status()
         text = res.json()
         project_name = RichText()
@@ -86,7 +85,7 @@ def create_report(config):
         logger.info("Fetching SBOM with vulnerabilities")
         res = requests.get(url+"bom/cyclonedx/project/"+project
                            +"?format=json&variant=withVulnerabilities&download=true",
-                           headers=headers, verify=False, timeout=10000)
+                           headers=headers, verify=verify_tls(), timeout=10000)
         res.raise_for_status()
         text = res.json()
         vulnerabilities = text.get("vulnerabilities") or []
@@ -99,7 +98,7 @@ def create_report(config):
         # get components
         res = requests.get(url+"component/project/"+project+
             "?searchText=&pageSize=99999&pageNumber=1",
-            headers=headers, verify=False, timeout=10000)
+            headers=headers, verify=verify_tls(), timeout=10000)
         res.raise_for_status()
         for component in res.json():
             try:
@@ -144,7 +143,8 @@ def create_report(config):
                 severity_level, severity = get_severity(list(x.get("severity")
                                                              for x in vuln.get("ratings")))
                 cve_paas = json.loads(requests.get(os.getenv("CVEPAAS_URL")+"/get_info/"+cve_id,
-                  verify=False, timeout=100).text) if os.getenv("CVEPAAS_URL") and cve_id else {}
+                  verify=verify_tls(), timeout=100).text) \
+                  if os.getenv("CVEPAAS_URL") and cve_id else {}
                 add_info = []
                 if cve_paas.get("Priority") and cve_paas.get("Priority").lower() == "critical":
                     links = cve_paas["Details"]["Links"]

--- a/backend/reports.py
+++ b/backend/reports.py
@@ -66,7 +66,8 @@ def create_report(config):
        # get common info about project
         logger.info("Fetching project metadata")
         res = requests.get(url+"project/"+project, headers=headers, verify=False, timeout=1000)
-        text = json.loads(res.text)
+        res.raise_for_status()
+        text = res.json()
         project_name = RichText()
         project_name_str = text.get("name")
         project_name.add(project_name_str,
@@ -94,7 +95,8 @@ def create_report(config):
         res = requests.get(url+"bom/cyclonedx/project/"+project
                            +"?format=json&variant=withVulnerabilities&download=true",
                            headers=headers, verify=False, timeout=10000)
-        text = json.loads(res.text)
+        res.raise_for_status()
+        text = res.json()
         vulnerabilities = text.get("vulnerabilities") or []
         deps_deps = {}
         for deps in text.get("dependencies") or []:
@@ -106,7 +108,8 @@ def create_report(config):
         res = requests.get(url+"component/project/"+project+
             "?searchText=&pageSize=99999&pageNumber=1",
             headers=headers, verify=False, timeout=10000)
-        for component in json.loads(res.text):
+        res.raise_for_status()
+        for component in res.json():
             try:
                 last_version = component.get("repositoryMeta").get("latestVersion")
             except AttributeError:

--- a/backend/reports.py
+++ b/backend/reports.py
@@ -47,21 +47,13 @@ def create_report(config):
         # read config and validate parameters
         raw_url = config.get("url")[0] if not os.getenv("DTRG_URL") else os.getenv("DTRG_URL")
         url = check_format_url(raw_url)
-        if not isinstance(url, str):
-            # can be error from backend.param_validators
-            raise url # pylint: disable=raising-bad-type
         token = config.get("token")[0] if not os.getenv("DTRG_TOKEN") else os.getenv("DTRG_TOKEN")
         headers = check_token(token, url)
-        if not isinstance(headers, dict):
-            # can be error from backend.param_validators
-            raise headers # pylint: disable=raising-bad-type
         project_raw = config.get("project")[0]
         project_match = re.search(r"\(([^()]+)\)\s*$", project_raw)
         if not project_match:
             raise ValueError("Project value must end with (uuid)")
         project = check_project(project_match.group(1))
-        if not isinstance(project, str):
-            raise project
 
        # get common info about project
         logger.info("Fetching project metadata")

--- a/backend/reports.py
+++ b/backend/reports.py
@@ -66,15 +66,16 @@ def create_report(config):
         project_name_str = text.get("name")
         project_name.add(project_name_str,
             url_id=doc.build_url_id(url.split("api/v1/")[0]+"projects/"+project))
+        metrics = text.get("metrics") or {}
         project_info.update({
             "name": project_name,
             "version": text.get("version") or "no version",
             "lastBomImport": datetime.fromtimestamp(int(text.get("lastBomImport") or
                                                     0)/1000).strftime("%d.%m.%Y %H:%M"),
             "date": datetime.now().strftime("%d.%m.%Y %H:%M"),
-            "componentsCount": text.get("metrics").get("components"),
-            "vulnsCount": text.get("metrics").get("vulnerabilities"),
-            "vulnComponentsCount": text.get("metrics").get("vulnerableComponents")
+            "componentsCount": metrics.get("components"),
+            "vulnsCount": metrics.get("vulnerabilities"),
+            "vulnComponentsCount": metrics.get("vulnerableComponents")
         })
         logger.debug(f"Project info retrieved: {project_info}")
         if text.get("directDependencies"):
@@ -91,7 +92,7 @@ def create_report(config):
         text = json.loads(res.text)
         vulnerabilities = text.get("vulnerabilities") or []
         deps_deps = {}
-        for deps in text.get("dependencies"):
+        for deps in text.get("dependencies") or []:
             deps_deps.update({
                 deps.get("ref"):deps.get("dependsOn")
             })
@@ -221,7 +222,7 @@ def create_report(config):
                 if isinstance(vuln.get("word_link"), RichText):
                     ws3.cell(row=num+2+vuln_num, column=2).hyperlink=vuln.get("link")
                 ws3.cell(row=num+2+vuln_num, column=3, value=vuln.get("severity"))
-                ws3.cell(row=num+2+vuln_num, column=4, value=vuln.get("priority").lower())
+                ws3.cell(row=num+2+vuln_num, column=4, value=(vuln.get("priority") or "").lower())
                 ws3.cell(row=num+2+vuln_num, column=5, value=component.get("name"))
                 ws3.cell(row=num+2+vuln_num, column=6, value=component.get("version"))
                 ws3.cell(row=num+2+vuln_num, column=7, value=vuln.get("add_info"))

--- a/dockerfile
+++ b/dockerfile
@@ -1,11 +1,15 @@
 FROM python:3.14.3-alpine3.23
 RUN apk update && apk upgrade && apk add bash
 
-COPY . /app
 WORKDIR /app
 
-RUN pip install --upgrade pip
-RUN pip install -r requirements.txt
+COPY requirements.txt /app/
+RUN pip install --upgrade pip && pip install -r requirements.txt
+
+COPY . /app
+
+RUN addgroup -S dtrg && adduser -S dtrg -G dtrg && chown -R dtrg:dtrg /app
+USER dtrg
 
 ENTRYPOINT [ "python" ]
 CMD [ "app.py" ]

--- a/templates/graph.html
+++ b/templates/graph.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="resource://content-accessible/plaintext.css">
+    <style>
+        pre {
+            line-height: 1.4;
+        }
+        .pkg {
+            color: #333;
+        }
+        .vuln {
+            font-weight: bold;
+        }
+        .vuln-critical {
+            color: #b30000;
+        }
+        .vuln-high {
+            color: #d9534f;
+        }
+        .vuln-medium {
+            color: #f0ad4e;
+        }
+        .vuln-low {
+            color: #5bc0de;
+        }
+    </style>
+</head>
+<body>
+    <pre>{{ graph|safe }}</pre>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -42,8 +42,15 @@
         integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo="
         crossorigin="anonymous">
     </script>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.13/css/select2.min.css" rel="stylesheet" />
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.13/js/select2.min.js"></script>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.13/css/select2.min.css"
+        rel="stylesheet"
+        integrity="sha512-nMNlpuaDPrqlEls3IX/Q56H36qvBASwb3ipuo3MxeWbsQB1881ox0cRv7UPTgBlriqoynt35KjEwgGUeUXIPnw=="
+        crossorigin="anonymous"
+        referrerpolicy="no-referrer" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.13/js/select2.min.js"
+        integrity="sha512-2ImtlRlf2VVmiGZsjm9bEyhjGW4dU7B6TNwh/hx/iSByxNENtj3WVE6o/9Lj4TJeVXPi4bnOIMXFIJJAeufa0A=="
+        crossorigin="anonymous"
+        referrerpolicy="no-referrer"></script>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## What

22 commits applying findings from a code review of the current main. Each commit is one fix so the history reads as a punch list. No structural changes (folders, modules, naming, doc style preserved).

## Bug fixes
- Missing f-prefix on two debug log lines (logged literal `{var}` placeholders).
- `get_severity` crashed with `KeyError` on unknown / null severity values from DT.
- `metrics`, `dependencies`, `priority` chains crashed with `AttributeError` when DT omitted those fields.
- Project UUID parsed by fragile `split("(")[1].split(")")[0]` — replaced with regex + clear error.
- Dependency-graph traversal had no cycle protection (depth was the only limiter); added a `visited` set and skipped missing nodes.
- Switched DT API calls to `res.raise_for_status()` + `res.json()` so HTTP errors surface directly.
- Removed dead `if not isinstance(...): raise <value>` branches that pylint had to silence with `# pylint: disable=raising-bad-type`.
- Cosmetic: `find(...) != -1` → `in`; `open (...)` stray space.

## Security hardening
- TLS verification configurable via new `DTRG_VERIFY_TLS` (default `true`); previously `verify=False` was hard-coded everywhere with `urllib3.disable_warnings()` globally.
- Stable Flask secret via new `DTRG_SECRET_KEY`; previously regenerated on every start (broke CSRF across restarts and across workers).
- `DTRG_DEBUG=true` combined with a non-loopback bind now refuses to start unless the new `DTRG_DEBUG_ALLOW_REMOTE=true` is set, because the Werkzeug debugger console is RCE-equivalent. Also exposed `DTRG_HOST` for an explicit bind address.
- Removed `os.chdir("reports/")` in the ZIP builder — Flask's threaded server made that a process-wide race. ZIP is now built with absolute paths.
- CVE id flowing into the CVE-PaaS URL is now restricted to canonical `CVE-YYYY-NNNN[N+]`; a malformed id from upstream can no longer steer the outbound HTTP path.
- DT API token redacted before debug-logging the form body.
- Outbound HTTP timeouts unified behind new `DTRG_HTTP_TIMEOUT` (default 120s); previously 100 / 1000 / 10000s — last value was wedge-a-worker territory.

## Templates / infra
- Inline graph HTML+CSS f-string moved to `templates/graph.html`.
- Added Subresource Integrity (`integrity` + `crossorigin`) to the select2 CDN assets (jQuery already had SRI). Hashes computed against the pinned 4.0.13 build.
- Dockerfile: dedicated non-root `dtrg` user, requirements installed before source copy for layer caching.
- Added `.dockerignore` (skips `.git`, `.github`, report artifacts, etc.).
- Migrated semgrep workflow off the archived `returntocorp/semgrep-action` to `semgrep ci` inside the official `semgrep/semgrep` container.

## Docs
- Fixed README typos (`DTRG_DEGUB`, stray Cyrillic `и`).
- Documented all new env vars: `DTRG_VERIFY_TLS`, `DTRG_SECRET_KEY`, `DTRG_HOST`, `DTRG_DEBUG_ALLOW_REMOTE`, `DTRG_HTTP_TIMEOUT`.
- Added Tests as a roadmap item.

## Out of scope (deliberately deferred)
- SSRF allowlist for the user-supplied DT URL.
- Splitting the long `create_report` function.
- Actually writing the smoke/unit tests (tracked in roadmap).

## Test plan
- [ ] Generate a report against a real DT instance with default env (TLS verify on)
- [ ] Generate a report against a self-signed DT with `DTRG_VERIFY_TLS=false`
- [ ] Verify `DTRG_DEBUG=true` + default host refuses to start; succeeds with `DTRG_HOST=127.0.0.1` or `DTRG_DEBUG_ALLOW_REMOTE=true`
- [ ] ZIP download contains `result.docx`, `result.xlsx`, and `graph.html` when applicable
- [ ] Concurrent report requests no longer race on cwd / file paths
- [ ] Docker image runs as non-root (`docker run ... id` shows uid != 0)