### PR TITLE
Add JSON API endpoints for CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
-reports/result*
 __pycache__
 test/
 .DS_Store
-reports/graph.html
-reports/reports.zip
 autoupdate_version.sh

--- a/README.md
+++ b/README.md
@@ -24,6 +24,30 @@ docker run --name dtrg -d -p 5000:5000 ghcr.io/denimoll/dt-report-generator
     - Project - project ID (Object Identifier parameter in Project Details or identifier in the URL after ".../projects/")
 3. Click "Get report"
 4. Wait
+## CI usage
+For pipelines a JSON API is exposed alongside the form. It returns the same ZIP, but does not need a browser session and is suitable for `curl` from a build job.
+
+Generate a report:
+```
+curl -fSL -o report.zip \
+    -H "X-DTRG-Key: $DTRG_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{"project":"<uuid>"}' \
+    http://dtrg.internal:5000/api/v1/reports/get_report
+```
+List projects to look up a UUID:
+```
+curl -fsSL \
+    -H "X-DTRG-Key: $DTRG_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{}' \
+    http://dtrg.internal:5000/api/v1/projects | jq '.[] | {name, version, uuid}'
+```
+Notes:
+- `url` and `token` can be omitted from the request body when `DTRG_URL` and `DTRG_TOKEN` are set in the dtrg environment.
+- The endpoints are open by default. When the service is reachable beyond a trusted network, set `DTRG_API_KEY` so requests must present the same key in the `X-DTRG-Key` (or `Authorization: Bearer ...`) header.
+- Errors come back as `{"error": "..."}` with a non-200 status, never as a redirect.
+
 ## Advanced usage
 You can set environment variable. A couple of examples: \
 \
@@ -57,6 +81,7 @@ All environment variables:
 * DTRG_VERIFY_TLS - verify TLS certificate of DT and CVE-PaaS (default: true; set to false only for self-signed test instances)
 * DTRG_HTTP_TIMEOUT - timeout in seconds for outbound HTTP calls to DT and CVE-PaaS (default: 120)
 * DTRG_SECRET_KEY - Flask secret key. Set a stable value when running multiple workers or behind a reverse proxy so CSRF tokens stay valid across restarts. If unset, a random key is generated on each start.
+* DTRG_API_KEY - shared secret required on the /api/v1/* endpoints. When unset (default) those endpoints are open and only network controls protect them; when set, callers must present the same value in an `X-DTRG-Key` or `Authorization: Bearer ...` header.
 * CVEPAAS_URL - [CVE-PaaS](https://github.com/denimoll/CVE-PaaS) address
 ## Roadmap
 Planned functionality:

--- a/app.py
+++ b/app.py
@@ -3,10 +3,13 @@
 import logging
 import os
 import secrets
+import shutil
+import tempfile
 import zipfile
 
 from flask import (
     Flask,
+    after_this_request,
     flash,
     jsonify,
     redirect,
@@ -42,55 +45,54 @@ def index():
 
 
 # REPORTS GROUP
-def clear_tmp_files():
-    """ Remove old files in reports directory """
-    logger.info("Clearing temporary files in 'reports/' directory")
-    for filename in os.listdir("reports/"):
-        if filename.split(".")[0] != "draft":
-            try:
-                os.remove(os.path.join("reports/", filename))
-                logger.debug(f"Removed file: {filename}")
-            except OSError as e:
-                logger.warning(f"Failed to remove file {filename}: {e}")
-                flash(str(e), "danger")
-
-def create_zip(with_graph=False):
-    """ Additional function for create final archive with all materials """
+def create_zip(output_dir, with_graph=False):
+    """ Bundle the rendered files inside output_dir into reports.zip """
     logger.info("Creating ZIP archive with report files")
+    zip_path = os.path.join(output_dir, "reports.zip")
     try:
-        with zipfile.ZipFile("reports/reports.zip", "w", zipfile.ZIP_DEFLATED) as zipf:
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zipf:
             for file in ["result.docx", "result.xlsx"]:
-                zipf.write(os.path.join("reports", file), arcname=file)
+                zipf.write(os.path.join(output_dir, file), arcname=file)
             if with_graph:
-                zipf.write("reports/graph.html", arcname="graph.html")
+                zipf.write(os.path.join(output_dir, "graph.html"), arcname="graph.html")
         logger.info("ZIP archive created successfully")
-        return True
+        return zip_path
     except OSError as e:
         logger.error(f"Error while creating ZIP: {e}")
         flash(str(e), "danger")
-        return False
+        return None
 
 def _redact(form_data):
     """ Drop secret-bearing fields from form data before logging """
     return {k: ("<redacted>" if k in {"token", "csrf_token"} else v)
             for k, v in form_data.items()}
 
+def _new_output_dir():
+    """ Create a unique output directory for a single report request """
+    return tempfile.mkdtemp(prefix="dtrg-")
+
 @app.route("/reports/get_report", methods=["POST"])
 def get_report():
     """ API Endpoint /reports/get_report """
     logger.info("Received request to generate report")
-    clear_tmp_files()
+    output_dir = _new_output_dir()
+
+    @after_this_request
+    def _cleanup(response):
+        response.call_on_close(lambda: shutil.rmtree(output_dir, ignore_errors=True))
+        return response
+
     data = request.form.to_dict(flat=False)
     logger.debug(f"Form data received: {_redact(data)}")
-    report, components = create_report(data)
-    with_graph = create_graph(components) if components else False
-    if isinstance(report, str) and create_zip(with_graph):
+    report, components = create_report(data, output_dir)
+    with_graph = create_graph(components, output_dir) if components else False
+    zip_path = create_zip(output_dir, with_graph) if isinstance(report, str) else None
+    if zip_path:
         logger.info("Report generation successful. Sending ZIP file")
-        return send_file("reports/reports.zip", as_attachment=True, download_name=f"{report}.zip")
-    else:
-        logger.error(f"Report generation failed: {report}")
-        flash(str(report), "danger")
-        return redirect(url_for("index"))
+        return send_file(zip_path, as_attachment=True, download_name=f"{report}.zip")
+    logger.error(f"Report generation failed: {report}")
+    flash(str(report), "danger")
+    return redirect(url_for("index"))
 
 
 # PROJECTS GROUP
@@ -111,13 +113,13 @@ def get_all_projects():
 
 
 # GRAPH GROUP
-def create_graph(components):
-    """ Additional function for create graph in backend """
+def create_graph(components, output_dir):
+    """ Render the dependency graph HTML into output_dir """
     logger.info("Generating graph from components")
     graph = get_graph(components)
     if graph:
         rendered = render_template("graph.html", graph=graph)
-        with open("reports/graph.html", "w", encoding="utf-8") as f:
+        with open(os.path.join(output_dir, "graph.html"), "w", encoding="utf-8") as f:
             f.write(rendered)
         logger.info("Graph HTML saved successfully")
         return True

--- a/app.py
+++ b/app.py
@@ -97,6 +97,17 @@ def _new_output_dir():
     """ Create a unique output directory for a single report request """
     return tempfile.mkdtemp(prefix="dtrg-")
 
+def _build_report(config, output_dir):
+    """ Run create_report + graph + zip and return (zip_path, name_or_error) """
+    report, components = create_report(config, output_dir)
+    if not isinstance(report, str):
+        return None, report
+    with_graph = create_graph(components, output_dir) if components else False
+    zip_path = create_zip(output_dir, with_graph)
+    if not zip_path:
+        return None, "Failed to build report archive"
+    return zip_path, report
+
 @app.route("/reports/get_report", methods=["POST"])
 def get_report():
     """ API Endpoint /reports/get_report """
@@ -110,15 +121,38 @@ def get_report():
 
     data = request.form.to_dict(flat=False)
     logger.debug(f"Form data received: {_redact(data)}")
-    report, components = create_report(data, output_dir)
-    with_graph = create_graph(components, output_dir) if components else False
-    zip_path = create_zip(output_dir, with_graph) if isinstance(report, str) else None
+    zip_path, report = _build_report(data, output_dir)
     if zip_path:
         logger.info("Report generation successful. Sending ZIP file")
         return send_file(zip_path, as_attachment=True, download_name=f"{report}.zip")
     logger.error(f"Report generation failed: {report}")
     flash(str(report), "danger")
     return redirect(url_for("index"))
+
+@app.route("/api/v1/reports/get_report", methods=["POST"])
+@require_api_key
+def get_report_api():
+    """ JSON-friendly entrypoint for CI: returns the ZIP directly """
+    logger.info("Received API request to generate report")
+    body = request.get_json(silent=True) or {}
+    if not body and request.form:
+        body = request.form.to_dict(flat=True)
+    config = {k: [str(body[k])] for k in ("url", "token", "project") if body.get(k)}
+    logger.debug(f"API report request: {_redact(config)}")
+
+    output_dir = _new_output_dir()
+
+    @after_this_request
+    def _cleanup(response):
+        response.call_on_close(lambda: shutil.rmtree(output_dir, ignore_errors=True))
+        return response
+
+    zip_path, report = _build_report(config, output_dir)
+    if not zip_path:
+        logger.error(f"API report generation failed: {report}")
+        return jsonify(error=str(report)), 400
+    return send_file(zip_path, as_attachment=True,
+                     download_name=f"{report}.zip", mimetype="application/zip")
 
 
 # PROJECTS GROUP

--- a/app.py
+++ b/app.py
@@ -11,6 +11,7 @@ from functools import wraps
 
 from flask import (
     Flask,
+    Response,
     after_this_request,
     flash,
     jsonify,
@@ -170,6 +171,23 @@ def get_all_projects():
         logger.error(f"Error fetching projects: {e}")
         flash(f"An internal error has occurred. {str(e)}", "danger")
         return jsonify(error_msg=f"An internal error has occurred. {str(e)}"), 400
+
+@app.route("/api/v1/projects", methods=["POST"])
+@require_api_key
+def get_all_projects_api():
+    """ JSON-friendly entrypoint for CI: returns the DT project list """
+    body = request.get_json(silent=True) or {}
+    if not body and request.form:
+        body = request.form.to_dict(flat=True)
+    url = os.getenv("DTRG_URL") or body.get("url") or ""
+    token = os.getenv("DTRG_TOKEN") or body.get("token") or ""
+    if not url or not token:
+        return jsonify(error="url and token are required"), 400
+    logger.debug(f"API projects request for: {url}")
+    result = get_projects(url, token)
+    if isinstance(result, dict):
+        return jsonify(result), 502
+    return Response(result, mimetype="application/json")
 
 
 # GRAPH GROUP

--- a/app.py
+++ b/app.py
@@ -1,11 +1,13 @@
 """ Main logic dependency track report generator """
 
+import hmac
 import logging
 import os
 import secrets
 import shutil
 import tempfile
 import zipfile
+from functools import wraps
 
 from flask import (
     Flask,
@@ -34,6 +36,30 @@ logger = logging.getLogger(__name__)
 app = Flask(__name__)
 app.config["SECRET_KEY"] = os.getenv("DTRG_SECRET_KEY") or secrets.token_hex(16)
 bootstrap = Bootstrap5(app)
+
+
+def _presented_api_key():
+    """ Pull the dtrg API key from X-DTRG-Key or Authorization: Bearer ... """
+    header = request.headers.get("X-DTRG-Key")
+    if header:
+        return header
+    auth = request.headers.get("Authorization", "")
+    if auth.lower().startswith("bearer "):
+        return auth.split(" ", 1)[1].strip()
+    return ""
+
+def require_api_key(view):
+    """ Gate a route on DTRG_API_KEY when the env var is set """
+    @wraps(view)
+    def wrapper(*args, **kwargs):
+        expected = os.getenv("DTRG_API_KEY") or ""
+        if expected:
+            presented = _presented_api_key()
+            if not presented or not hmac.compare_digest(presented, expected):
+                logger.warning("API call rejected: invalid or missing DTRG_API_KEY")
+                return jsonify(error="unauthorized"), 401
+        return view(*args, **kwargs)
+    return wrapper
 
 
 # INDEX PAGE

--- a/backend/reports.py
+++ b/backend/reports.py
@@ -49,15 +49,15 @@ def create_report(config, output_dir):
 
     try:
         # read config and validate parameters
-        raw_url = config.get("url")[0] if not os.getenv("DTRG_URL") else os.getenv("DTRG_URL")
+        raw_url = os.getenv("DTRG_URL") or (config.get("url") or [""])[0]
         url = check_format_url(raw_url)
-        token = config.get("token")[0] if not os.getenv("DTRG_TOKEN") else os.getenv("DTRG_TOKEN")
+        token = os.getenv("DTRG_TOKEN") or (config.get("token") or [""])[0]
         headers = check_token(token, url)
-        project_raw = config.get("project")[0]
+        project_raw = (config.get("project") or [""])[0]
+        # form flow sends "name version (uuid)"; API flow sends a bare UUID
         project_match = re.search(r"\(([^()]+)\)\s*$", project_raw)
-        if not project_match:
-            raise ValueError("Project value must end with (uuid)")
-        project = check_project(project_match.group(1))
+        project_id = project_match.group(1) if project_match else project_raw.strip()
+        project = check_project(project_id)
 
        # get common info about project
         logger.info("Fetching project metadata")
@@ -244,8 +244,9 @@ def create_report(config, output_dir):
         logger.info("Excel report saved")
 
         # return
-        return f"""{config.get('project')[0].split(' ')[0]} {project_info.get('version')} \
-        ({datetime.now().strftime('%d.%m.%Y')})""", components
+        report_name = project_name_str or project_id
+        return (f"{report_name} {project_info.get('version')} "
+                f"({datetime.now().strftime('%d.%m.%Y')})", components)
     except (ValueError, ConnectionError) as e:
         logger.error(f"Error while generating report: {e}")
         return e, []

--- a/backend/reports.py
+++ b/backend/reports.py
@@ -38,8 +38,8 @@ def get_severity(severities):
     return level, [key for key, val in severity.items() if val == level][0]
 
 
-def create_report(config):
-    """ Create report from DT """
+def create_report(config, output_dir):
+    """ Create report from DT into the per-request output_dir """
     logger.info("Report generation started")
     # variables
     doc = DocxTemplate("reports/draft.docx") # docx template
@@ -197,8 +197,8 @@ def create_report(config):
             "project": project_info,
             "components": vuln_components
         })
-        doc.save("reports/result.docx")
-        logger.info("Word report saved as reports/result.docx")
+        doc.save(os.path.join(output_dir, "result.docx"))
+        logger.info("Word report saved")
 
         # render and save result in excel report
         logger.info("Generating Excel report")
@@ -240,8 +240,8 @@ def create_report(config):
         if not vuln_components:
             del excel["Vulnerable dependencies"]
             del excel["All issues"]
-        excel.save("reports/result.xlsx")
-        logger.info("Excel report saved as reports/result.xlsx")
+        excel.save(os.path.join(output_dir, "result.xlsx"))
+        logger.info("Excel report saved")
 
         # return
         return f"""{config.get('project')[0].split(' ')[0]} {project_info.get('version')} \


### PR DESCRIPTION
Closes the user's CI request: report generation and project listing without going through the HTML form / browser session.

## What
- New `POST /api/v1/reports/get_report` — accepts JSON `{url, token, project}` (any field optional when `DTRG_URL` / `DTRG_TOKEN` are baked into env), returns the same ZIP the form returns. Errors come back as `{"error": "..."}` with a non-200 status.
- New `POST /api/v1/projects` — JSON list of DT projects so CI can resolve a UUID by name.
- Both endpoints are gated by the new `DTRG_API_KEY` env var; when unset they remain open (suitable for private networks). When set, the request must present the same value via `X-DTRG-Key` or `Authorization: Bearer ...` (constant-time compared with `hmac.compare_digest`).
- Reports are now rendered into a per-request `tempfile.mkdtemp()` and the directory is removed in `response.call_on_close`. Closes the lingering race where parallel `/reports/get_report` calls clobbered each other's `result.docx` / `result.xlsx` / `reports.zip` — a pre-existing problem that the API endpoint would have made loud.
- `create_report` now accepts a bare project UUID (the form's `name version (uuid)` is still parsed). The download filename is derived from the resolved project name, falling back to UUID when the API caller has only that.

## New env var
- `DTRG_API_KEY` — optional shared secret for `/api/v1/*`. Documented in README.

## Out of scope (deliberately)
- VEX support (issue #1) — next PR.
- OpenAPI/swagger spec — already a roadmap item; this PR ships endpoints, not their spec.
- CSRF on the existing form endpoint — currently not enforced server-side either, so the new API is consistent with existing behaviour. Worth a separate PR.

## Test plan
- [ ] Generate a report from a real DT instance via curl (`DTRG_URL` + `DTRG_TOKEN` set, no `DTRG_API_KEY`)
- [ ] Same call with `DTRG_API_KEY` set: missing/invalid key → 401, valid key (header + Bearer) → 200 ZIP
- [ ] `/api/v1/projects` returns DT JSON list
- [ ] Form-based UI flow still works (regression check on per-request tempdir)
- [ ] Two concurrent report requests both succeed (no shared file races)

Smoke-tested locally:
- 401 without/with-wrong key on both endpoints
- 400 with proper JSON on missing URL when env not set
- Bearer header auth path works