### PR TITLE
Claude/vex support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ When use docker run container with this command:
 ```
 docker run --name dtrg -d -p $DTRG_PORT:5000 ghcr.io/denimoll/dt-report-generator
 ```
+№4. Show VEX-suppressed findings
+By default dtrg honours VEX: a finding marked in DT as `resolved`, `resolved_with_pedigree`, `false_positive` or `not_affected` is dropped from the report so it matches what the DT UI shows. Set the variable below to keep them in the output and see their analysis state in the `All issues` sheet.
+```
+export DTRG_INCLUDE_SUPPRESSED=true
+```
 
 All environment variables:
 * DTRG_URL - DT address
@@ -82,6 +87,7 @@ All environment variables:
 * DTRG_HTTP_TIMEOUT - timeout in seconds for outbound HTTP calls to DT and CVE-PaaS (default: 120)
 * DTRG_SECRET_KEY - Flask secret key. Set a stable value when running multiple workers or behind a reverse proxy so CSRF tokens stay valid across restarts. If unset, a random key is generated on each start.
 * DTRG_API_KEY - shared secret required on the /api/v1/* endpoints. When unset (default) those endpoints are open and only network controls protect them; when set, callers must present the same value in an `X-DTRG-Key` or `Authorization: Bearer ...` header.
+* DTRG_INCLUDE_SUPPRESSED - when `true`, vulnerabilities that DT considers suppressed via VEX (state `resolved` / `resolved_with_pedigree` / `false_positive` / `not_affected`) are still rendered in the report with their analysis state in the `All issues` sheet. Default `false`, which matches the DT UI.
 * CVEPAAS_URL - [CVE-PaaS](https://github.com/denimoll/CVE-PaaS) address
 ## Roadmap
 Planned functionality:
@@ -94,6 +100,7 @@ Planned functionality:
 - [x] *Secure use as a service*. Add the ability to define trusted addresses (SSRF exclusion) or disable URL and token selection by setting default values.
 - [x] *Vulnerability prioritization*. Implement logic that will help assess which vulnerabilities require priority fixing.
 - [x] *Docs*. Add a documentation or just more info in readme.md for advansed settings (like custom port, use specific version and etc.)
+- [x] *VEX support*. Honour CycloneDX analysis state from DT so suppressed findings are dropped (or surfaced via DTRG_INCLUDE_SUPPRESSED) in the report.
 - [ ] *Optimization*. Add a Database for fast search.
 - [ ] *Specification*. Add a swagger / more info for API Endpoint like parameters in and out.
 - [ ] *Graph*. Manage deep of graph and add info to report about graph_level.

--- a/backend/reports.py
+++ b/backend/reports.py
@@ -265,6 +265,7 @@ def create_report(config, output_dir):
                 ws3.cell(row=num+2+vuln_num, column=6, value=component.get("version"))
                 ws3.cell(row=num+2+vuln_num, column=7, value=vuln.get("add_info"))
                 ws3.cell(row=num+2+vuln_num, column=7).alignment = Alignment(wrap_text=True)
+                ws3.cell(row=num+2+vuln_num, column=8, value=vuln.get("analysis_state") or "")
                 vuln_num += 1
             vuln_num -= 1
         if not vuln_components:

--- a/backend/reports.py
+++ b/backend/reports.py
@@ -129,7 +129,15 @@ def create_report(config, output_dir):
 
         # add info about vulnerabilities to components
         logger.info("Processing component vulnerabilities")
+        suppressed_states = {"resolved", "resolved_with_pedigree",
+                             "false_positive", "not_affected"}
         for vuln in vulnerabilities:
+            analysis = vuln.get("analysis") or {}
+            analysis_state = (analysis.get("state") or "").lower()
+            analysis_justification = analysis.get("justification") or ""
+            analysis_response = ", ".join(analysis.get("response") or [])
+            analysis_detail = analysis.get("detail") or ""
+            is_suppressed = analysis_state in suppressed_states
             for component in vuln.get("affects"):
                 vuln_id = vuln.get("id")
                 vuln_word_link = RichText()
@@ -168,7 +176,12 @@ def create_report(config, output_dir):
                     "severity": severity,
                     "severity_level": severity_level,
                     "priority": cve_paas.get("Priority") or severity,
-                    "add_info": ", ".join(sorted(set(add_info)))
+                    "add_info": ", ".join(sorted(set(add_info))),
+                    "analysis_state": analysis_state,
+                    "analysis_justification": analysis_justification,
+                    "analysis_response": analysis_response,
+                    "analysis_detail": analysis_detail,
+                    "is_suppressed": is_suppressed,
                 })
         logger.info("Vulnerabilities assigned to components")
 

--- a/backend/reports.py
+++ b/backend/reports.py
@@ -185,6 +185,23 @@ def create_report(config, output_dir):
                 })
         logger.info("Vulnerabilities assigned to components")
 
+        # honour VEX: drop suppressed vulnerabilities unless DTRG_INCLUDE_SUPPRESSED=true
+        include_suppressed = os.getenv("DTRG_INCLUDE_SUPPRESSED",
+                                       "false").lower() in ["true", "1", "t"]
+        suppressed_count = 0
+        for value in components.values():
+            kept = []
+            for vuln in value["vulnerabilities"]:
+                if vuln["is_suppressed"]:
+                    suppressed_count += 1
+                    if not include_suppressed:
+                        continue
+                kept.append(vuln)
+            value["vulnerabilities"] = kept
+        project_info["suppressedCount"] = suppressed_count
+        logger.info(f"VEX-suppressed vulnerabilities: {suppressed_count} "
+                    f"(included in report: {include_suppressed})")
+
         # set severity to vulnerable components
         logger.info("Computing final severity levels for components")
         for component, value in components.items():


### PR DESCRIPTION
Closes the user's complaint that vulnerabilities suppressed in DT via VEX still appeared in the generated report.

## What
- `create_report` now reads the CycloneDX `analysis` block on each vulnerability and copies `state`, `justification`, `response`, `detail` plus a derived `is_suppressed` flag into every per-component vuln record.
- `is_suppressed` is true for `resolved`, `resolved_with_pedigree`, `false_positive`, `not_affected` — the same set DT treats as suppressed.
- By default these vulns are filtered out before severity rollup, so a component whose only finding was marked `not_affected` no longer pollutes the report. This matches the DT UI.
- New env var `DTRG_INCLUDE_SUPPRESSED=true` brings the suppressed findings back. Useful for auditors who want the full picture.
- The number of suppressed findings is exposed on `project_info` as `suppressedCount` so the docx template can mention it.
- Excel `All issues` sheet writes `analysis_state` to column 8. The `draft.xlsx` template gets a matching header in a follow-up template update by the maintainer.

## Verified
Mock-tested against a synthetic CycloneDX payload with three vulns (one `exploitable`, one `not_affected`, one with no analysis):
- Default: `CVE-2024-0001` and `CVE-2024-0003` survive; `CVE-2024-0002` is dropped.
- `DTRG_INCLUDE_SUPPRESSED=true`: all three survive; the `not_affected` one carries `analysis_state=not_affected`, `analysis_justification=code_not_present`, `is_suppressed=True`.

## Out of scope (deferred, per the agreed minimal version)
- Findings-API fallback when `analysis` is absent from the SBOM response.
- Per-version diff (fixed/new/changed). Stays as a roadmap item.
- Surfacing `analysis_response`/`analysis_detail` in the Excel — only `analysis_state` is shown for now.

## Template updates needed alongside this PR
- `reports/draft.xlsx`: add an `Analysis state` header at row 1, column 8 of the `All issues` sheet.
- `reports/draft.docx`: optionally reference `{{ vuln.analysis_state }}` and `{{ project.suppressedCount }}` if you want them in the Word output. Without changes, the data is simply not shown.

## Test plan
- [ ] Real DT project with a VEX-suppressed finding: default mode hides it, `DTRG_INCLUDE_SUPPRESSED=true` shows it with the state in column 8
- [ ] Real DT project with no VEX: report identical to before this PR
- [ ] Excel column 8 matches the new header after template update