### PR TITLE
Add pytest test suite + CI workflow (roadmap: Tests)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,33 @@
+name: Tests
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Run pytest
+        run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 __pycache__
-test/
 .DS_Store
+.pytest_cache
 autoupdate_version.sh

--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ All environment variables:
 * DTRG_API_KEY - shared secret required on the /api/v1/* endpoints. When unset (default) those endpoints are open and only network controls protect them; when set, callers must present the same value in an `X-DTRG-Key` or `Authorization: Bearer ...` header.
 * DTRG_INCLUDE_SUPPRESSED - when `true`, vulnerabilities that DT considers suppressed via VEX (state `resolved` / `resolved_with_pedigree` / `false_positive` / `not_affected`) are still rendered in the report with their analysis state in the `All issues` sheet. Default `false`, which matches the DT UI.
 * CVEPAAS_URL - [CVE-PaaS](https://github.com/denimoll/CVE-PaaS) address
+## Development
+Tests live under `tests/` and run with pytest:
+```
+pip install -r requirements-dev.txt
+pytest -q
+```
+The same suite runs on every push/PR via `.github/workflows/tests.yml`.
 ## Roadmap
 Planned functionality:
 - [x] *Project search*. Simplify the search for projects via the provided link and token.
@@ -101,7 +108,7 @@ Planned functionality:
 - [x] *Vulnerability prioritization*. Implement logic that will help assess which vulnerabilities require priority fixing.
 - [x] *Docs*. Add a documentation or just more info in readme.md for advansed settings (like custom port, use specific version and etc.)
 - [x] *VEX support*. Honour CycloneDX analysis state from DT so suppressed findings are dropped (or surfaced via DTRG_INCLUDE_SUPPRESSED) in the report.
-- [ ] *Optimization*. Add a Database for fast search.
+- [x] *Tests*. Smoke/unit tests for validators, severity merge, graph traversal, VEX filter and the API auth paths, run on every PR.
+- [ ] *Optimization*. Pagination + ajax-search for large project lists (so 10k+ projects in DT do not lock up the form).
 - [ ] *Specification*. Add a swagger / more info for API Endpoint like parameters in and out.
 - [ ] *Graph*. Manage deep of graph and add info to report about graph_level.
-- [ ] *Tests*. Add smoke/unit tests (validators, severity merge, graph traversal) so regressions are caught before release.

--- a/backend/dependency_graph.py
+++ b/backend/dependency_graph.py
@@ -29,10 +29,10 @@ def get_graph(components, depth=3):
         logger.debug(f"Expanding dependencies at depth={depth}")
         if visited is None:
             visited = set()
-        deps_deps = []
         copy_dependencies = copy.deepcopy(dependencies)
 
         for num, dependency in enumerate(copy_dependencies):
+            deps_deps = []
             for dep in dependency.get("dependencies") or []:
                 if dep in visited:
                     continue
@@ -41,9 +41,11 @@ def get_graph(components, depth=3):
                 if dep_value is None:
                     continue
                 deps_deps.append(dep_value)
+            if deps_deps and depth:
                 dependencies[num]["dependencies"] = update_direct_dependencies(
-                    copy.deepcopy(deps_deps), depth-1, visited) if depth and deps_deps else []
-            deps_deps = []
+                    copy.deepcopy(deps_deps), depth-1, visited)
+            else:
+                dependencies[num]["dependencies"] = []
         return dependencies
 
     def update_tree(tree, dependencies):
@@ -67,17 +69,19 @@ def get_graph(components, depth=3):
 
         return tree
 
-    direct_dependencies = [v for v in components.values() if v.get("is_direct_dependency")]
+    direct_uuids = {k for k, v in components.items() if v.get("is_direct_dependency")}
 
-    if not direct_dependencies:
+    if not direct_uuids:
         logger.info("No direct dependencies found")
         return 0
 
+    direct_dependencies = [components[k] for k in direct_uuids]
     logger.info(f"Found {len(direct_dependencies)} direct dependencies")
 
     tree = update_tree(
         tree,
-        update_direct_dependencies(copy.deepcopy(direct_dependencies), depth-1)
+        update_direct_dependencies(copy.deepcopy(direct_dependencies), depth-1,
+                                   visited=set(direct_uuids))
     )
 
     # Render tree to string

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+testpaths = tests
+pythonpath = .
+filterwarnings =
+    ignore::DeprecationWarning:flask_wtf

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest==8.3.4

--- a/tests/test_app_api.py
+++ b/tests/test_app_api.py
@@ -1,0 +1,117 @@
+""" Tests for the Flask app's HTTP routes (form + /api/v1/*) """
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import app as app_module
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("DTRG_API_KEY", "secret")
+    app_module.app.config.update(TESTING=True)
+    with app_module.app.test_client() as c:
+        yield c
+
+
+def test_index_renders(client):
+    response = client.get("/")
+    assert response.status_code == 200
+    assert b"Get report" in response.data
+
+
+# require_api_key
+
+def test_api_reports_unauthorized_without_key(client):
+    res = client.post("/api/v1/reports/get_report",
+                      data=json.dumps({"project": "abc"}),
+                      content_type="application/json")
+    assert res.status_code == 401
+    assert res.get_json() == {"error": "unauthorized"}
+
+
+def test_api_reports_unauthorized_with_wrong_key(client):
+    res = client.post("/api/v1/reports/get_report",
+                      headers={"X-DTRG-Key": "wrong"},
+                      data=json.dumps({"project": "abc"}),
+                      content_type="application/json")
+    assert res.status_code == 401
+
+
+def test_api_reports_accepts_x_dtrg_key(client):
+    """ Right key gets through auth (validation may still fail on missing URL) """
+    res = client.post("/api/v1/reports/get_report",
+                      headers={"X-DTRG-Key": "secret"},
+                      data=json.dumps({"project": "abc"}),
+                      content_type="application/json")
+    # Past auth, fails on URL validation -> 400
+    assert res.status_code == 400
+
+
+def test_api_reports_accepts_bearer_token(client):
+    res = client.post("/api/v1/reports/get_report",
+                      headers={"Authorization": "Bearer secret"},
+                      data=json.dumps({"project": "abc"}),
+                      content_type="application/json")
+    assert res.status_code == 400  # past auth, validator complains
+
+
+def test_api_reports_open_when_env_unset(monkeypatch):
+    """ Without DTRG_API_KEY the endpoint is open (private-network deploy) """
+    monkeypatch.delenv("DTRG_API_KEY", raising=False)
+    app_module.app.config.update(TESTING=True)
+    with app_module.app.test_client() as c:
+        res = c.post("/api/v1/reports/get_report",
+                     data=json.dumps({"project": "abc"}),
+                     content_type="application/json")
+    # No auth required, validator still complains about URL
+    assert res.status_code == 400
+
+
+# /api/v1/projects
+
+def test_api_projects_unauthorized_without_key(client):
+    res = client.post("/api/v1/projects",
+                      data=json.dumps({}),
+                      content_type="application/json")
+    assert res.status_code == 401
+
+
+def test_api_projects_400_without_url_or_token(client):
+    res = client.post("/api/v1/projects",
+                      headers={"X-DTRG-Key": "secret"},
+                      data=json.dumps({}),
+                      content_type="application/json")
+    assert res.status_code == 400
+    assert "url and token" in res.get_json()["error"]
+
+
+def test_api_projects_proxies_dt_response(client):
+    """ With env defaults set, the endpoint forwards what get_projects returns """
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.text = json.dumps([{"name": "proj", "uuid": "u"}])
+    with patch.object(app_module, "get_projects",
+                      return_value=fake_response.text) as mocked:
+        res = client.post("/api/v1/projects",
+                          headers={"X-DTRG-Key": "secret"},
+                          data=json.dumps({"url": "https://example.com",
+                                           "token": "t"}),
+                          content_type="application/json")
+    assert res.status_code == 200
+    assert res.headers["Content-Type"].startswith("application/json")
+    assert mocked.called
+
+
+def test_api_projects_502_when_get_projects_returns_error_dict(client):
+    with patch.object(app_module, "get_projects",
+                      return_value={"error": "Request to Dependency-Track failed"}):
+        res = client.post("/api/v1/projects",
+                          headers={"X-DTRG-Key": "secret"},
+                          data=json.dumps({"url": "https://example.com",
+                                           "token": "t"}),
+                          content_type="application/json")
+    assert res.status_code == 502
+    assert res.get_json()["error"] == "Request to Dependency-Track failed"

--- a/tests/test_dependency_graph.py
+++ b/tests/test_dependency_graph.py
@@ -1,0 +1,64 @@
+""" Tests for backend.dependency_graph """
+
+from backend.dependency_graph import get_graph
+
+
+def _component(name, *, is_direct=False, deps=None, vulns=None, severity=""):
+    """ Build a components-dict entry with the shape create_report produces """
+    return {
+        "name": name,
+        "version": "1.0",
+        "group": "",
+        "last_version": "1.0",
+        "is_direct_dependency": is_direct,
+        "dependencies": deps or [],
+        "vulnerabilities": vulns or [],
+        "severity": severity,
+        "severity_level": 0,
+        "graph_level": 0,
+    }
+
+
+def test_no_direct_dependencies_returns_zero():
+    components = {"a": _component("libA", is_direct=False)}
+    assert get_graph(components) == 0
+
+
+def test_renders_single_direct_dep():
+    components = {"a": _component("libA", is_direct=True)}
+    out = get_graph(components)
+    assert "libA" in out
+    assert "Application" in out
+
+
+def test_renders_nested_dep():
+    components = {
+        "a": _component("libA", is_direct=True, deps=["b"]),
+        "b": _component("libB"),
+    }
+    out = get_graph(components)
+    assert "libA" in out
+    assert "libB" in out
+    # libB rendered after libA in the tree output
+    assert out.index("libA") < out.index("libB")
+
+
+def test_depth_one_drops_children():
+    components = {
+        "a": _component("libA", is_direct=True, deps=["b"]),
+        "b": _component("libB"),
+    }
+    out = get_graph(components, depth=1)
+    assert "libA" in out
+    assert "libB" not in out
+
+
+def test_vulnerable_component_marked():
+    components = {
+        "a": _component("libA", is_direct=True,
+                        vulns=[{"id": "CVE-2024-0001"}],
+                        severity="critical"),
+    }
+    out = get_graph(components)
+    assert 'vuln-critical' in out
+    assert "[critical vuln]" in out

--- a/tests/test_dependency_graph.py
+++ b/tests/test_dependency_graph.py
@@ -53,6 +53,27 @@ def test_depth_one_drops_children():
     assert "libB" not in out
 
 
+def test_handles_cycle_without_recursion():
+    components = {
+        "a": _component("libA", is_direct=True, deps=["b"]),
+        "b": _component("libB", deps=["a"]),
+    }
+    out = get_graph(components, depth=10)
+    # libA listed exactly once thanks to the visited set; recursion bounded
+    assert out.count("libA") == 1
+    assert out.count("libB") == 1
+
+
+def test_skips_missing_dependency_uuid():
+    components = {
+        "a": _component("libA", is_direct=True, deps=["ghost"]),
+    }
+    # ghost does not exist in components; traversal should not crash
+    out = get_graph(components)
+    assert "libA" in out
+    assert "ghost" not in out
+
+
 def test_vulnerable_component_marked():
     components = {
         "a": _component("libA", is_direct=True,

--- a/tests/test_param_validators.py
+++ b/tests/test_param_validators.py
@@ -1,0 +1,93 @@
+""" Tests for backend.param_validators """
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from backend import param_validators as pv
+
+
+# verify_tls / http_timeout
+
+def test_verify_tls_default_true(monkeypatch):
+    monkeypatch.delenv("DTRG_VERIFY_TLS", raising=False)
+    assert pv.verify_tls() is True
+
+@pytest.mark.parametrize("value", ["false", "False", "0", "no", "anything-else"])
+def test_verify_tls_false_when_not_truthy(monkeypatch, value):
+    monkeypatch.setenv("DTRG_VERIFY_TLS", value)
+    assert pv.verify_tls() is False
+
+@pytest.mark.parametrize("value", ["true", "True", "1", "t"])
+def test_verify_tls_true_for_recognized_truthy(monkeypatch, value):
+    monkeypatch.setenv("DTRG_VERIFY_TLS", value)
+    assert pv.verify_tls() is True
+
+def test_http_timeout_default(monkeypatch):
+    monkeypatch.delenv("DTRG_HTTP_TIMEOUT", raising=False)
+    assert pv.http_timeout() == 120
+
+def test_http_timeout_explicit(monkeypatch):
+    monkeypatch.setenv("DTRG_HTTP_TIMEOUT", "30")
+    assert pv.http_timeout() == 30
+
+def test_http_timeout_falls_back_on_garbage(monkeypatch):
+    monkeypatch.setenv("DTRG_HTTP_TIMEOUT", "not-a-number")
+    assert pv.http_timeout() == 120
+
+
+# check_format_url
+
+def test_check_format_url_appends_api_path():
+    assert pv.check_format_url("https://dt.example.com") == "https://dt.example.com/api/v1/"
+
+def test_check_format_url_normalises_existing_api_path():
+    assert pv.check_format_url("https://dt.example.com/api/v2/") == "https://dt.example.com/api/v1/"
+
+def test_check_format_url_rejects_invalid():
+    with pytest.raises(ValueError, match="URL not valid"):
+        pv.check_format_url("not a url")
+
+def test_check_format_url_rejects_empty():
+    with pytest.raises(ValueError, match="URL not valid"):
+        pv.check_format_url("")
+
+
+# check_token
+
+def _ok_response():
+    res = MagicMock()
+    res.status_code = 200
+    res.text = "[]"
+    return res
+
+def test_check_token_returns_headers_on_success():
+    with patch.object(pv.requests, "get", return_value=_ok_response()):
+        assert pv.check_token("abc", "https://dt.example.com/api/v1/") == {"X-Api-Key": "abc"}
+
+def test_check_token_rejects_empty():
+    with pytest.raises(ValueError, match="Token not set"):
+        pv.check_token("", "https://dt.example.com/api/v1/")
+
+def test_check_token_raises_on_non_200():
+    bad = MagicMock(status_code=401, text="unauthorized")
+    with patch.object(pv.requests, "get", return_value=bad):
+        with pytest.raises(ConnectionError, match="connection"):
+            pv.check_token("abc", "https://dt.example.com/api/v1/")
+
+def test_check_token_raises_on_network_error():
+    with patch.object(pv.requests, "get", side_effect=requests.ConnectionError("boom")):
+        with pytest.raises(ConnectionError, match="Failed to connect"):
+            pv.check_token("abc", "https://dt.example.com/api/v1/")
+
+
+# check_project
+
+def test_check_project_returns_uuid():
+    assert pv.check_project("00000000-0000-0000-0000-000000000000") == \
+        "00000000-0000-0000-0000-000000000000"
+
+def test_check_project_rejects_empty():
+    with pytest.raises(ValueError, match="Project not set"):
+        pv.check_project("")

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,0 +1,192 @@
+""" Tests for backend.reports """
+
+import json
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backend import reports
+
+
+# get_severity
+
+def test_get_severity_picks_max_known():
+    level, label = reports.get_severity(["low", "high", "medium"])
+    assert label == "high"
+    assert level == 3
+
+def test_get_severity_handles_case():
+    level, label = reports.get_severity(["LOW", "Critical"])
+    assert label == "critical"
+    assert level == 4
+
+def test_get_severity_treats_unknown_as_zero():
+    level, label = reports.get_severity(["mystery", None, ""])
+    assert level == 0
+    # the function returns the first key whose value matches the level
+    assert label in {"unknown", "undefined", "info"}
+
+def test_get_severity_known_plus_unknown():
+    level, label = reports.get_severity(["mystery", "high"])
+    assert label == "high"
+    assert level == 3
+
+
+# VEX filtering through create_report (mocked DT API)
+
+def _fake_dt_get(payloads):
+    """ Build a side_effect that returns mock responses based on URL match.
+
+    payloads is a list of (predicate, body); the first predicate that matches
+    the request URL wins. predicate can be a substring or a callable.
+    """
+    def _matches(predicate, url):
+        return predicate(url) if callable(predicate) else predicate in url
+
+    def _get(url, headers=None, verify=None, timeout=None):
+        m = MagicMock()
+        m.status_code = 200
+        m.raise_for_status = lambda: None
+        body = next((b for pred, b in payloads if _matches(pred, url)), {})
+        m.text = json.dumps(body)
+        m.json = lambda b=body: b
+        return m
+    return _get
+
+
+def _config():
+    return {
+        "url": ["https://example.com"],
+        "token": ["t"],
+        "project": ["00000000-0000-0000-0000-000000000000"],
+    }
+
+
+def _payloads_with_vex():
+    return [
+        # check_token probe — exact endswith /project (no trailing slash or uuid)
+        (lambda u: u.endswith("/project"), []),
+        # SBOM with mixed analysis states
+        ("bom/cyclonedx", {
+            "vulnerabilities": [
+                {"bom-ref": "v1", "id": "CVE-2024-0001",
+                 "ratings": [{"severity": "high"}],
+                 "affects": [{"ref": "c1"}],
+                 "analysis": {"state": "exploitable"}},
+                {"bom-ref": "v2", "id": "CVE-2024-0002",
+                 "ratings": [{"severity": "critical"}],
+                 "affects": [{"ref": "c2"}],
+                 "analysis": {"state": "not_affected",
+                              "justification": "code_not_present"}},
+                {"bom-ref": "v3", "id": "CVE-2024-0003",
+                 "ratings": [{"severity": "medium"}],
+                 "affects": [{"ref": "c3"}]},
+            ],
+            "dependencies": [
+                {"ref": "c1", "dependsOn": []},
+                {"ref": "c2", "dependsOn": []},
+                {"ref": "c3", "dependsOn": []},
+            ],
+        }),
+        ("component/project", [
+            {"uuid": "c1", "name": "libA", "version": "1", "group": "",
+             "repositoryMeta": None},
+            {"uuid": "c2", "name": "libB", "version": "2", "group": "",
+             "repositoryMeta": None},
+            {"uuid": "c3", "name": "libC", "version": "3", "group": "",
+             "repositoryMeta": None},
+        ]),
+        # project metadata - matched last because the pattern is generic
+        ("/project/", {"name": "demo", "version": "1.0", "metrics": {},
+                       "directDependencies": "[]"}),
+    ]
+
+
+def _live_ids(components):
+    return sorted(v["id"] for c in components.values() for v in c["vulnerabilities"])
+
+
+def test_create_report_filters_suppressed_by_default(monkeypatch):
+    monkeypatch.delenv("DTRG_INCLUDE_SUPPRESSED", raising=False)
+    with tempfile.TemporaryDirectory() as td, \
+         patch.object(reports.requests, "get",
+                      side_effect=_fake_dt_get(_payloads_with_vex())):
+        report, components = reports.create_report(_config(), td)
+    assert isinstance(report, str)
+    assert _live_ids(components) == ["CVE-2024-0001", "CVE-2024-0003"]
+
+
+def test_create_report_keeps_suppressed_when_env_set(monkeypatch):
+    monkeypatch.setenv("DTRG_INCLUDE_SUPPRESSED", "true")
+    with tempfile.TemporaryDirectory() as td, \
+         patch.object(reports.requests, "get",
+                      side_effect=_fake_dt_get(_payloads_with_vex())):
+        report, components = reports.create_report(_config(), td)
+    assert _live_ids(components) == ["CVE-2024-0001", "CVE-2024-0002",
+                                     "CVE-2024-0003"]
+    suppressed = [v for c in components.values() for v in c["vulnerabilities"]
+                  if v["is_suppressed"]]
+    assert len(suppressed) == 1
+    assert suppressed[0]["analysis_state"] == "not_affected"
+    assert suppressed[0]["analysis_justification"] == "code_not_present"
+
+
+def test_create_report_records_suppressed_count(monkeypatch):
+    monkeypatch.delenv("DTRG_INCLUDE_SUPPRESSED", raising=False)
+    with tempfile.TemporaryDirectory() as td, \
+         patch.object(reports.requests, "get",
+                      side_effect=_fake_dt_get(_payloads_with_vex())):
+        reports.create_report(_config(), td)
+    # the fixture has exactly one not_affected finding
+    # we look at the rendered docx's project_info indirectly via the suppressed_count log path
+    # — easier: re-run with include=true and confirm the dropped one comes back
+    monkeypatch.setenv("DTRG_INCLUDE_SUPPRESSED", "true")
+    with tempfile.TemporaryDirectory() as td, \
+         patch.object(reports.requests, "get",
+                      side_effect=_fake_dt_get(_payloads_with_vex())):
+        _, components_full = reports.create_report(_config(), td)
+    monkeypatch.delenv("DTRG_INCLUDE_SUPPRESSED", raising=False)
+    with tempfile.TemporaryDirectory() as td, \
+         patch.object(reports.requests, "get",
+                      side_effect=_fake_dt_get(_payloads_with_vex())):
+        _, components_filtered = reports.create_report(_config(), td)
+    full_total = sum(len(c["vulnerabilities"]) for c in components_full.values())
+    filtered_total = sum(len(c["vulnerabilities"])
+                         for c in components_filtered.values())
+    assert full_total - filtered_total == 1
+
+
+# project parsing
+
+def test_create_report_accepts_bare_uuid(monkeypatch):
+    """ API path passes a bare UUID, not "name version (uuid)" """
+    monkeypatch.delenv("DTRG_INCLUDE_SUPPRESSED", raising=False)
+    with tempfile.TemporaryDirectory() as td, \
+         patch.object(reports.requests, "get",
+                      side_effect=_fake_dt_get(_payloads_with_vex())):
+        report, _ = reports.create_report(_config(), td)
+    assert isinstance(report, str)
+
+
+def test_create_report_extracts_uuid_from_form_value(monkeypatch):
+    """ Form path passes "name version (uuid)" """
+    monkeypatch.delenv("DTRG_INCLUDE_SUPPRESSED", raising=False)
+    cfg = {
+        "url": ["https://example.com"],
+        "token": ["t"],
+        "project": ["demo 1.0 (00000000-0000-0000-0000-000000000000)"],
+    }
+    with tempfile.TemporaryDirectory() as td, \
+         patch.object(reports.requests, "get",
+                      side_effect=_fake_dt_get(_payloads_with_vex())):
+        report, _ = reports.create_report(cfg, td)
+    assert isinstance(report, str)
+
+
+def test_create_report_returns_value_error_on_missing_url():
+    cfg = {"project": ["00000000-0000-0000-0000-000000000000"]}
+    with tempfile.TemporaryDirectory() as td:
+        report, components = reports.create_report(cfg, td)
+    assert isinstance(report, ValueError)
+    assert components == []


### PR DESCRIPTION
Closes the Tests roadmap item.

## What
- Adds `tests/` with 50 tests across 4 modules and a `pytest.ini` that puts the repo root on `sys.path` so test modules import `app` / `backend` directly.
- Adds `requirements-dev.txt` (pulls runtime deps + `pytest`).
- Removes the stale `test/` entry from `.gitignore`; adds `.pytest_cache`.
- New workflow `.github/workflows/tests.yml` runs `pytest -q` on push/PR against `main` and `develop`, with pip caching keyed on both requirements files.
- README gets a Development section and the roadmap is updated: Tests done; Optimization entry reframed as pagination + ajax-search.

## Coverage by module
- `tests/test_param_validators.py` — env-var parsing for `verify_tls` / `http_timeout` (including non-numeric fallback), URL normalisation, all four `check_token` paths, `check_project` empty rejection.
- `tests/test_dependency_graph.py` — single + nested rendering, depth=1 truncation, vulnerable-component span, cycle protection, missing-dep handling.
- `tests/test_reports.py` — `get_severity` over mixed-case / unknown / None, VEX filtering default + `DTRG_INCLUDE_SUPPRESSED=true`, project parsing for both form and API shapes, missing-URL returns ValueError.
- `tests/test_app_api.py` — auth paths on both `/api/v1/*` endpoints (401 without/with-wrong key, X-DTRG-Key + Bearer, open-by-default when env unset), `/api/v1/projects` validation, success and 502 paths.

## Bug surfaced and fixed
While writing the dependency_graph tests, two latent bugs in `update_direct_dependencies` showed up:
1. The `dependencies` field on a parent was only overwritten with the recursive result *inside* the inner loop. When all children were already-visited or missing, the field kept its original list of UUID strings, which then crashed `update_tree` with `'str' object has no attribute 'get'`.
2. The recursion fired once per child instead of once per parent.
The traversal now collects each parent's resolved children first and recurses once, with an explicit `[]` assignment when nothing remains. The visited set is also seeded with the direct-dep UUIDs so an `a→b→a` cycle no longer renders `libA` twice.

This change is included in the same commit as the cycle/missing-dep tests that exercise it.

## Test plan
- [x] `pytest -q` locally → 50/50 passing
- [ ] CI workflow turns green on this PR