### PR TITLE
Enforce CSRF on form endpoints; keep /api/v1/* exempt

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Notes:
 - `url` and `token` can be omitted from the request body when `DTRG_URL` and `DTRG_TOKEN` are set in the dtrg environment.
 - The endpoints are open by default. When the service is reachable beyond a trusted network, set `DTRG_API_KEY` so requests must present the same key in the `X-DTRG-Key` (or `Authorization: Bearer ...`) header.
 - Errors come back as `{"error": "..."}` with a non-200 status, never as a redirect.
+- These endpoints are deliberately CSRF-exempt (CI tooling has no session). The form endpoints (`/reports/get_report`, `/projects/get_all`) keep CSRF protection on; rely on `DTRG_API_KEY` and network controls for `/api/v1/*`.
 
 ## Advanced usage
 You can set environment variable. A couple of examples: \
@@ -85,7 +86,7 @@ All environment variables:
 * DTRG_DEBUG_ALLOW_REMOTE - explicit override that allows DTRG_DEBUG=true together with a non-loopback DTRG_HOST. Use only in trusted networks.
 * DTRG_VERIFY_TLS - verify TLS certificate of DT and CVE-PaaS (default: true; set to false only for self-signed test instances)
 * DTRG_HTTP_TIMEOUT - timeout in seconds for outbound HTTP calls to DT and CVE-PaaS (default: 120)
-* DTRG_SECRET_KEY - Flask secret key. Set a stable value when running multiple workers or behind a reverse proxy so CSRF tokens stay valid across restarts. If unset, a random key is generated on each start.
+* DTRG_SECRET_KEY - Flask secret key used to sign session cookies and CSRF tokens for the form endpoints (`/`, `/reports/get_report`, `/projects/get_all`). Set a stable value when running multiple workers or behind a reverse proxy so tokens stay valid across restarts. If unset, a random key is generated on each start.
 * DTRG_API_KEY - shared secret required on the /api/v1/* endpoints. When unset (default) those endpoints are open and only network controls protect them; when set, callers must present the same value in an `X-DTRG-Key` or `Authorization: Bearer ...` header.
 * DTRG_INCLUDE_SUPPRESSED - when `true`, vulnerabilities that DT considers suppressed via VEX (state `resolved` / `resolved_with_pedigree` / `false_positive` / `not_affected`) are still rendered in the report with their analysis state in the `All issues` sheet. Default `false`, which matches the DT UI.
 * CVEPAAS_URL - [CVE-PaaS](https://github.com/denimoll/CVE-PaaS) address

--- a/app.py
+++ b/app.py
@@ -22,6 +22,7 @@ from flask import (
     url_for,
 )
 from flask_bootstrap import Bootstrap5
+from flask_wtf.csrf import CSRFProtect
 
 from backend.dependency_graph import get_graph
 from backend.projects import get_projects
@@ -37,6 +38,7 @@ logger = logging.getLogger(__name__)
 app = Flask(__name__)
 app.config["SECRET_KEY"] = os.getenv("DTRG_SECRET_KEY") or secrets.token_hex(16)
 bootstrap = Bootstrap5(app)
+csrf = CSRFProtect(app)
 
 
 def _presented_api_key():
@@ -131,6 +133,7 @@ def get_report():
     return redirect(url_for("index"))
 
 @app.route("/api/v1/reports/get_report", methods=["POST"])
+@csrf.exempt
 @require_api_key
 def get_report_api():
     """ JSON-friendly entrypoint for CI: returns the ZIP directly """
@@ -173,6 +176,7 @@ def get_all_projects():
         return jsonify(error_msg=f"An internal error has occurred. {str(e)}"), 400
 
 @app.route("/api/v1/projects", methods=["POST"])
+@csrf.exempt
 @require_api_key
 def get_all_projects_api():
     """ JSON-friendly entrypoint for CI: returns the DT project list """

--- a/templates/index.html
+++ b/templates/index.html
@@ -104,7 +104,8 @@
                         url: "/projects/get_all",
                         data: {
                             "url": $("#url").val(),
-                            "token": $("#token").val()
+                            "token": $("#token").val(),
+                            "csrf_token": $('input[name="csrf_token"]').val()
                         },
                         success: function(data) {
                             projects = jQuery.parseJSON(data);

--- a/tests/test_app_api.py
+++ b/tests/test_app_api.py
@@ -115,3 +115,34 @@ def test_api_projects_502_when_get_projects_returns_error_dict(client):
                           content_type="application/json")
     assert res.status_code == 502
     assert res.get_json()["error"] == "Request to Dependency-Track failed"
+
+
+# CSRF behaviour
+
+def test_form_post_rejected_without_csrf_token(client):
+    """ /reports/get_report and /projects/get_all are form endpoints under CSRF """
+    res = client.post("/reports/get_report",
+                      data={"url": "https://example.com", "token": "t",
+                            "project": "demo (00000000-0000-0000-0000-000000000000)"})
+    assert res.status_code == 400
+    # The CSRF rejection message comes from flask-wtf, distinct from the API
+    # endpoints' JSON error bodies.
+    assert b"CSRF" in res.data or b"csrf" in res.data
+
+
+def test_projects_form_endpoint_rejected_without_csrf_token(client):
+    res = client.post("/projects/get_all",
+                      data={"url": "https://example.com", "token": "t"})
+    assert res.status_code == 400
+    assert b"CSRF" in res.data or b"csrf" in res.data
+
+
+def test_api_endpoints_remain_csrf_exempt(client):
+    """ /api/v1/* must not require a CSRF token (CI flow) """
+    res = client.post("/api/v1/projects",
+                      headers={"X-DTRG-Key": "secret"},
+                      data=json.dumps({}),
+                      content_type="application/json")
+    # 400 from input validation, NOT from CSRFProtect
+    assert res.status_code == 400
+    assert res.get_json()["error"] == "url and token are required"


### PR DESCRIPTION
Fixes a latent CSRF gap: the form rendered a CSRF token but the server never validated it.

## Why
`FlaskForm` puts a `csrf_token` hidden field into the rendered form, but no `CSRFProtect` was attached to the app and the view didn't call `form.validate_on_submit()`. So any third-party page could POST to `/reports/get_report` or `/projects/get_all` from a victim's browser and make dtrg pull an arbitrary DT instance using the victim's saved credentials. The protection looked present but didn't run.

## What
- `CSRFProtect(app)` is now registered. Form POSTs without a valid token return 400.
- `/api/v1/reports/get_report` and `/api/v1/projects` are marked `@csrf.exempt`. They are JSON-only, designed for CI without a browser session — `DTRG_API_KEY` + network controls are the boundary there.
- `templates/index.html`'s AJAX call to `/projects/get_all` now reads the `csrf_token` hidden input that flask-wtf renders inside the form and passes it alongside `url`/`token`, so the project dropdown still populates.
- README clarifies CSRF behaviour for both endpoint families.

## Test plan
- [x] `pytest -q` → 53/53 (3 new tests covering form rejection, exempt API behaviour)
- [ ] Form: open `/`, submit a real report — works (token present in form)
- [ ] Form: try to POST `/reports/get_report` from a different origin without the token — 400
- [ ] AJAX dropdown still loads the project list (token forwarded)
- [ ] CI: `curl` against `/api/v1/*` still works without any CSRF header