### PR TITLE
Configurable graph depth + per-component graph_level (roadmap: Graph)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ All environment variables:
 * DTRG_SECRET_KEY - Flask secret key used to sign session cookies and CSRF tokens for the form endpoints (`/`, `/reports/get_report`, `/projects/get_all`). Set a stable value when running multiple workers or behind a reverse proxy so tokens stay valid across restarts. If unset, a random key is generated on each start.
 * DTRG_API_KEY - shared secret required on the /api/v1/* endpoints. When unset (default) those endpoints are open and only network controls protect them; when set, callers must present the same value in an `X-DTRG-Key` or `Authorization: Bearer ...` header.
 * DTRG_INCLUDE_SUPPRESSED - when `true`, vulnerabilities that DT considers suppressed via VEX (state `resolved` / `resolved_with_pedigree` / `false_positive` / `not_affected`) are still rendered in the report with their analysis state in the `All issues` sheet. Default `false`, which matches the DT UI.
+* DTRG_GRAPH_DEPTH - max depth of the dependency graph traversal. Direct dependencies are level 1, their children level 2, etc. The level of each component is shown in column G of the `Vulnerable dependencies` sheet; components beyond the depth limit show an empty cell. Default 3.
 * CVEPAAS_URL - [CVE-PaaS](https://github.com/denimoll/CVE-PaaS) address
 ## Development
 Tests live under `tests/` and run with pytest:
@@ -111,5 +112,5 @@ Planned functionality:
 - [x] *VEX support*. Honour CycloneDX analysis state from DT so suppressed findings are dropped (or surfaced via DTRG_INCLUDE_SUPPRESSED) in the report.
 - [x] *Tests*. Smoke/unit tests for validators, severity merge, graph traversal, VEX filter and the API auth paths, run on every PR.
 - [ ] *Optimization*. Pagination + ajax-search for large project lists (so 10k+ projects in DT do not lock up the form).
+- [x] *Graph*. Configurable traversal depth via `DTRG_GRAPH_DEPTH`; per-component level surfaced in the report.
 - [ ] *Specification*. Add a swagger / more info for API Endpoint like parameters in and out.
-- [ ] *Graph*. Manage deep of graph and add info to report about graph_level.

--- a/backend/dependency_graph.py
+++ b/backend/dependency_graph.py
@@ -5,20 +5,63 @@ import logging
 
 from anytree import Node, RenderTree
 
+from backend.param_validators import graph_depth
+
 logger = logging.getLogger(__name__)
 
 
-def get_graph(components, depth=3):
+def compute_graph_levels(components, depth=None):
+    """
+    Walk the dependency graph and write graph_level back into each component.
+
+    Direct dependencies get level 1. Their children get level 2, and so on.
+    Components that are not reached (no path from a direct dep, or beyond
+    the depth limit) keep their pre-existing graph_level (typically None).
+    Each component is visited once: the shallowest path wins.
+
+    Args:
+        components: A dictionary of components, indexed by ID. Mutated in place.
+        depth: Max depth to walk. Defaults to DTRG_GRAPH_DEPTH (env-controlled).
+    """
+    if depth is None:
+        depth = graph_depth()
+
+    direct_uuids = {k for k, v in components.items() if v.get("is_direct_dependency")}
+    if not direct_uuids:
+        return
+
+    visited = set(direct_uuids)
+    for uuid in direct_uuids:
+        components[uuid]["graph_level"] = 1
+
+    frontier = [(uuid, 1) for uuid in direct_uuids]
+    while frontier:
+        next_frontier = []
+        for uuid, level in frontier:
+            if level >= depth:
+                continue
+            for child in components[uuid].get("dependencies") or []:
+                if child in visited or child not in components:
+                    continue
+                visited.add(child)
+                components[child]["graph_level"] = level + 1
+                next_frontier.append((child, level + 1))
+        frontier = next_frontier
+
+
+def get_graph(components, depth=None):
     """
     Generate a dependency graph from the components dictionary.
 
     Args:
         components: A dictionary of components, indexed by ID.
-        depth: Max depth of dependencies to walk.
+        depth: Max depth of dependencies to walk. Defaults to DTRG_GRAPH_DEPTH.
 
     Returns:
         A formatted string representation of the tree, or 0 if no dependencies found.
     """
+    if depth is None:
+        depth = graph_depth()
     logger.debug(f"Generating graph with depth={depth}")
 
     # create Tree root

--- a/backend/param_validators.py
+++ b/backend/param_validators.py
@@ -22,6 +22,14 @@ def http_timeout() -> int:
         return 120
 
 
+def graph_depth() -> int:
+    """ Default depth for the dependency graph traversal """
+    try:
+        return int(os.getenv("DTRG_GRAPH_DEPTH", "3"))
+    except ValueError:
+        return 3
+
+
 if not verify_tls():
     urllib3.disable_warnings()
 

--- a/backend/reports.py
+++ b/backend/reports.py
@@ -258,6 +258,9 @@ def create_report(config, output_dir):
                 final_severity = str(component.get("severity"))
             ws2.cell(row=num+2, column=5, value=final_severity)
             ws2.cell(row=num+2, column=6, value=str(component.get("last_version")))
+            graph_level = component.get("graph_level")
+            ws2.cell(row=num+2, column=7,
+                     value="" if graph_level is None else graph_level)
             for vuln in component.get("vulnerabilities"):
                 ws3.cell(row=num+2+vuln_num, column=1, value=num+1+vuln_num)
                 ws3.cell(row=num+2+vuln_num, column=2, value=vuln.get("id"))

--- a/backend/reports.py
+++ b/backend/reports.py
@@ -11,6 +11,7 @@ from docxtpl import DocxTemplate, RichText
 from openpyxl import load_workbook
 from openpyxl.styles import Alignment
 
+from backend.dependency_graph import compute_graph_levels
 from backend.param_validators import (
     check_format_url,
     check_project,
@@ -122,7 +123,7 @@ def create_report(config, output_dir):
                     "vulnerabilities": [],
                     "severity": "",
                     "severity_level": 0,
-                    "graph_level": 0
+                    "graph_level": None,
                 }
             })
         logger.info(f"{len(components)} components processed")
@@ -220,6 +221,9 @@ def create_report(config, output_dir):
                                       key=lambda item: item[1]["severity_level"],
                                       reverse=True))).values())
         logger.info(f"{len(vuln_components)} vulnerable components found")
+
+        # populate graph_level on each component before rendering the reports
+        compute_graph_levels(components)
 
         # render and save result in word report
         logger.info("Generating Word report")

--- a/tests/test_dependency_graph.py
+++ b/tests/test_dependency_graph.py
@@ -1,6 +1,6 @@
 """ Tests for backend.dependency_graph """
 
-from backend.dependency_graph import get_graph
+from backend.dependency_graph import compute_graph_levels, get_graph
 
 
 def _component(name, *, is_direct=False, deps=None, vulns=None, severity=""):
@@ -15,7 +15,7 @@ def _component(name, *, is_direct=False, deps=None, vulns=None, severity=""):
         "vulnerabilities": vulns or [],
         "severity": severity,
         "severity_level": 0,
-        "graph_level": 0,
+        "graph_level": None,
     }
 
 
@@ -83,3 +83,95 @@ def test_vulnerable_component_marked():
     out = get_graph(components)
     assert 'vuln-critical' in out
     assert "[critical vuln]" in out
+
+
+# compute_graph_levels
+
+def test_compute_graph_levels_marks_direct_deps_as_one():
+    components = {
+        "a": _component("libA", is_direct=True),
+        "b": _component("libB", is_direct=True),
+    }
+    compute_graph_levels(components)
+    assert components["a"]["graph_level"] == 1
+    assert components["b"]["graph_level"] == 1
+
+
+def test_compute_graph_levels_descends():
+    components = {
+        "a": _component("libA", is_direct=True, deps=["b"]),
+        "b": _component("libB", deps=["c"]),
+        "c": _component("libC"),
+    }
+    compute_graph_levels(components, depth=5)
+    assert components["a"]["graph_level"] == 1
+    assert components["b"]["graph_level"] == 2
+    assert components["c"]["graph_level"] == 3
+
+
+def test_compute_graph_levels_picks_minimum_via_bfs():
+    # libC reachable both as a direct dep (level 1) and as a child of libB
+    components = {
+        "a": _component("libA", is_direct=True, deps=["b"]),
+        "b": _component("libB", deps=["c"]),
+        "c": _component("libC", is_direct=True),
+    }
+    compute_graph_levels(components)
+    assert components["c"]["graph_level"] == 1
+
+
+def test_compute_graph_levels_respects_depth():
+    components = {
+        "a": _component("libA", is_direct=True, deps=["b"]),
+        "b": _component("libB", deps=["c"]),
+        "c": _component("libC"),
+    }
+    compute_graph_levels(components, depth=2)
+    assert components["a"]["graph_level"] == 1
+    assert components["b"]["graph_level"] == 2
+    assert components["c"]["graph_level"] is None  # cut by depth
+
+
+def test_compute_graph_levels_unreachable_stays_none():
+    components = {
+        "a": _component("libA", is_direct=True),
+        "b": _component("libB"),  # not direct, not depended on
+    }
+    compute_graph_levels(components)
+    assert components["a"]["graph_level"] == 1
+    assert components["b"]["graph_level"] is None
+
+
+def test_compute_graph_levels_no_op_without_direct_deps():
+    components = {"a": _component("libA")}
+    compute_graph_levels(components)
+    assert components["a"]["graph_level"] is None
+
+
+def test_compute_graph_levels_uses_env_default(monkeypatch):
+    monkeypatch.setenv("DTRG_GRAPH_DEPTH", "1")
+    components = {
+        "a": _component("libA", is_direct=True, deps=["b"]),
+        "b": _component("libB"),
+    }
+    compute_graph_levels(components)  # no explicit depth
+    assert components["a"]["graph_level"] == 1
+    assert components["b"]["graph_level"] is None  # depth=1 stops at direct deps
+
+
+def test_compute_graph_levels_handles_cycle():
+    components = {
+        "a": _component("libA", is_direct=True, deps=["b"]),
+        "b": _component("libB", deps=["a"]),
+    }
+    compute_graph_levels(components, depth=10)
+    assert components["a"]["graph_level"] == 1
+    assert components["b"]["graph_level"] == 2  # not revisited as a's child
+
+
+def test_compute_graph_levels_skips_missing_uuid():
+    components = {
+        "a": _component("libA", is_direct=True, deps=["ghost"]),
+    }
+    compute_graph_levels(components)  # must not crash
+    assert components["a"]["graph_level"] == 1

--- a/tests/test_param_validators.py
+++ b/tests/test_param_validators.py
@@ -36,6 +36,18 @@ def test_http_timeout_falls_back_on_garbage(monkeypatch):
     monkeypatch.setenv("DTRG_HTTP_TIMEOUT", "not-a-number")
     assert pv.http_timeout() == 120
 
+def test_graph_depth_default(monkeypatch):
+    monkeypatch.delenv("DTRG_GRAPH_DEPTH", raising=False)
+    assert pv.graph_depth() == 3
+
+def test_graph_depth_explicit(monkeypatch):
+    monkeypatch.setenv("DTRG_GRAPH_DEPTH", "7")
+    assert pv.graph_depth() == 7
+
+def test_graph_depth_falls_back_on_garbage(monkeypatch):
+    monkeypatch.setenv("DTRG_GRAPH_DEPTH", "deep")
+    assert pv.graph_depth() == 3
+
 
 # check_format_url
 


### PR DESCRIPTION
Closes the Graph roadmap entry. Two parts: depth becomes env-controlled, and `graph_level` (which was previously dead — initialised but never written to) now actually carries the depth at which a component sits in the dependency tree.

## What
- New env `DTRG_GRAPH_DEPTH` (default 3) read via `param_validators.graph_depth()` in the same style as `verify_tls` / `http_timeout`. `get_graph` and the new `compute_graph_levels` both default through it.
- New `compute_graph_levels(components, depth)` in `backend.dependency_graph`: BFS over the dependency graph from direct deps. Direct deps get level 1, their children level 2, etc. Shortest path wins (BFS). Components not reached — either not in any direct-dep subtree or beyond the depth limit — keep `graph_level=None`.
- `create_report` initialises `graph_level=None` (was 0) and calls `compute_graph_levels(components)` right before rendering, so both the docx and xlsx outputs see populated levels.
- Excel "Vulnerable dependencies" sheet writes `graph_level` to column G. `None` becomes empty string so the cell is blank for unreached components.
- README documents the env var and the new column.

## Important
The xlsx template needs a `Graph level` header in row 1 of column G of the `Vulnerable dependencies` sheet. The maintainer is updating `reports/draft.xlsx` alongside this PR, same dance as the VEX `Analysis state` column.

## Out of scope (deferred)
- Surfacing `graph_level` in the docx template — the data is in the Jinja context, so adding `{{ component.graph_level }}` is a template tweak the maintainer can apply when convenient.
- Annotating the rendered text graph (`graph.html`) with level numbers — the graph already shows depth visually via indentation; numeric labels would be redundant noise.

## Test plan
- [x] `pytest -q` → 65/65 passing (12 new tests)
  - `compute_graph_levels`: direct deps at level 1, BFS picks shortest, depth cuts off correctly, unreachable stays None, env default, cycle handling, missing UUIDs.
  - `graph_depth()` helper: default, explicit, garbage fallback.
- [ ] Real DT project: column G in Excel shows 1 for direct deps, increments for nested
- [ ] `DTRG_GRAPH_DEPTH=1` cuts off everything past direct deps; column G empty for them
- [ ] `DTRG_GRAPH_DEPTH=10` deeper trees populate further