### PR TITLE
Add OpenAPI spec and Swagger UI via flasgger (roadmap: Specification)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Notes:
 - The endpoints are open by default. When the service is reachable beyond a trusted network, set `DTRG_API_KEY` so requests must present the same key in the `X-DTRG-Key` (or `Authorization: Bearer ...`) header.
 - Errors come back as `{"error": "..."}` with a non-200 status, never as a redirect.
 - These endpoints are deliberately CSRF-exempt (CI tooling has no session). The form endpoints (`/reports/get_report`, `/projects/get_all`) keep CSRF protection on; rely on `DTRG_API_KEY` and network controls for `/api/v1/*`.
+- The full OpenAPI spec is served at [`/apispec.json`](http://localhost:5000/apispec.json) and the Swagger UI at [`/apidocs/`](http://localhost:5000/apidocs/), so you can explore request shapes and try calls from the browser.
 
 ## Advanced usage
 You can set environment variable. A couple of examples: \
@@ -113,4 +114,4 @@ Planned functionality:
 - [x] *Tests*. Smoke/unit tests for validators, severity merge, graph traversal, VEX filter and the API auth paths, run on every PR.
 - [ ] *Optimization*. Pagination + ajax-search for large project lists (so 10k+ projects in DT do not lock up the form).
 - [x] *Graph*. Configurable traversal depth via `DTRG_GRAPH_DEPTH`; per-component level surfaced in the report.
-- [ ] *Specification*. Add a swagger / more info for API Endpoint like parameters in and out.
+- [x] *Specification*. OpenAPI 2.0 spec served at `/apispec.json`; Swagger UI at `/apidocs/`.

--- a/app.py
+++ b/app.py
@@ -21,6 +21,7 @@ from flask import (
     send_file,
     url_for,
 )
+from flasgger import Swagger
 from flask_bootstrap import Bootstrap5
 from flask_wtf.csrf import CSRFProtect
 
@@ -39,6 +40,43 @@ app = Flask(__name__)
 app.config["SECRET_KEY"] = os.getenv("DTRG_SECRET_KEY") or secrets.token_hex(16)
 bootstrap = Bootstrap5(app)
 csrf = CSRFProtect(app)
+
+# OpenAPI / Swagger UI at /apidocs/, raw spec at /apispec.json.
+swagger = Swagger(app, config={
+    "headers": [],
+    "specs": [{
+        "endpoint": "apispec",
+        "route": "/apispec.json",
+        "rule_filter": lambda rule: True,
+        "model_filter": lambda tag: True,
+    }],
+    "static_url_path": "/flasgger_static",
+    "swagger_ui": True,
+    "specs_route": "/apidocs/",
+}, template={
+    "swagger": "2.0",
+    "info": {
+        "title": "dt-report-generator API",
+        "description": "Generate Dependency-Track reports from a browser form "
+                       "or from CI. The /api/v1/* endpoints are JSON, "
+                       "CSRF-exempt, and gated by DTRG_API_KEY when set.",
+        "version": "1.0",
+    },
+    "securityDefinitions": {
+        "ApiKey": {
+            "type": "apiKey",
+            "in": "header",
+            "name": "X-DTRG-Key",
+            "description": "DTRG_API_KEY value. Required only if the env var is set.",
+        },
+        "Bearer": {
+            "type": "apiKey",
+            "in": "header",
+            "name": "Authorization",
+            "description": "'Bearer <DTRG_API_KEY>'. Alternative to X-DTRG-Key.",
+        },
+    },
+})
 
 
 def _presented_api_key():
@@ -68,7 +106,16 @@ def require_api_key(view):
 # INDEX PAGE
 @app.route("/", methods=["GET"])
 def index():
-    """ Index page """
+    """Render the HTML form for browser users.
+    ---
+    tags:
+      - browser
+    produces:
+      - text/html
+    responses:
+      200:
+        description: HTML page with the report-generation form.
+    """
     form = GetReportForm()
     return render_template("index.html", form=form)
 
@@ -113,7 +160,39 @@ def _build_report(config, output_dir):
 
 @app.route("/reports/get_report", methods=["POST"])
 def get_report():
-    """ API Endpoint /reports/get_report """
+    """Browser form submission. Prefer /api/v1/reports/get_report from CI.
+    ---
+    tags:
+      - browser
+    consumes:
+      - application/x-www-form-urlencoded
+    produces:
+      - application/zip
+      - text/html
+    parameters:
+      - in: formData
+        name: csrf_token
+        required: true
+        type: string
+        description: Token rendered into the form by Flask-WTF. Required.
+      - in: formData
+        name: url
+        type: string
+      - in: formData
+        name: token
+        type: string
+      - in: formData
+        name: project
+        type: string
+        description: '"name version (uuid)" as produced by the form select.'
+    responses:
+      200:
+        description: ZIP archive with the rendered reports.
+      302:
+        description: Redirect back to the form on validation failure.
+      400:
+        description: CSRF token missing or invalid.
+    """
     logger.info("Received request to generate report")
     output_dir = _new_output_dir()
 
@@ -136,7 +215,57 @@ def get_report():
 @csrf.exempt
 @require_api_key
 def get_report_api():
-    """ JSON-friendly entrypoint for CI: returns the ZIP directly """
+    """Generate a DT report and return it as a ZIP.
+    ---
+    tags:
+      - api
+    security:
+      - ApiKey: []
+      - Bearer: []
+    consumes:
+      - application/json
+    produces:
+      - application/zip
+      - application/json
+    parameters:
+      - in: body
+        name: body
+        required: true
+        schema:
+          type: object
+          required:
+            - project
+          properties:
+            url:
+              type: string
+              description: DT instance URL. Optional when DTRG_URL is set.
+              example: https://dependencytrack.example.com
+            token:
+              type: string
+              description: DT API key. Optional when DTRG_TOKEN is set.
+            project:
+              type: string
+              description: DT project UUID.
+              example: 00000000-0000-0000-0000-000000000000
+    responses:
+      200:
+        description: ZIP archive with result.docx, result.xlsx and graph.html.
+      400:
+        description: Validation error (missing field or upstream rejected).
+        schema:
+          type: object
+          properties:
+            error:
+              type: string
+      401:
+        description: DTRG_API_KEY is set and the request did not present it.
+        schema:
+          type: object
+          properties:
+            error:
+              type: string
+              example: unauthorized
+    """
     logger.info("Received API request to generate report")
     body = request.get_json(silent=True) or {}
     if not body and request.form:
@@ -162,7 +291,31 @@ def get_report_api():
 # PROJECTS GROUP
 @app.route("/projects/get_all", methods=["POST"])
 def get_all_projects():
-    """ API Endpoint /projects/get_all """
+    """AJAX project list for the browser form. Prefer /api/v1/projects from CI.
+    ---
+    tags:
+      - browser
+    consumes:
+      - application/x-www-form-urlencoded
+    produces:
+      - application/json
+    parameters:
+      - in: formData
+        name: csrf_token
+        required: true
+        type: string
+      - in: formData
+        name: url
+        type: string
+      - in: formData
+        name: token
+        type: string
+    responses:
+      200:
+        description: DT project list.
+      400:
+        description: CSRF or upstream error.
+    """
     logger.info("Received request to fetch all projects")
     data = request.form.to_dict(flat=False)
     try:
@@ -179,7 +332,50 @@ def get_all_projects():
 @csrf.exempt
 @require_api_key
 def get_all_projects_api():
-    """ JSON-friendly entrypoint for CI: returns the DT project list """
+    """List Dependency-Track projects.
+    ---
+    tags:
+      - api
+    security:
+      - ApiKey: []
+      - Bearer: []
+    consumes:
+      - application/json
+    produces:
+      - application/json
+    parameters:
+      - in: body
+        name: body
+        required: false
+        schema:
+          type: object
+          properties:
+            url:
+              type: string
+              description: DT instance URL. Optional when DTRG_URL is set.
+            token:
+              type: string
+              description: DT API key. Optional when DTRG_TOKEN is set.
+    responses:
+      200:
+        description: JSON array of DT project objects (forwarded from DT).
+      400:
+        description: Missing url and/or token (and no env defaults).
+        schema:
+          type: object
+          properties:
+            error:
+              type: string
+      401:
+        description: DTRG_API_KEY is set and the request did not present it.
+      502:
+        description: Upstream DT request failed.
+        schema:
+          type: object
+          properties:
+            error:
+              type: string
+    """
     body = request.get_json(silent=True) or {}
     if not body and request.form:
         body = request.form.to_dict(flat=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Flask==3.1.3
 Bootstrap-Flask==2.5.0
 Flask-WTF==1.3.0
+flasgger==0.9.7.1
 
 docxtpl==0.20.2
 openpyxl==3.1.5

--- a/tests/test_app_api.py
+++ b/tests/test_app_api.py
@@ -146,3 +146,23 @@ def test_api_endpoints_remain_csrf_exempt(client):
     # 400 from input validation, NOT from CSRFProtect
     assert res.status_code == 400
     assert res.get_json()["error"] == "url and token are required"
+
+
+# OpenAPI spec
+
+def test_apispec_json_lists_api_routes(client):
+    res = client.get("/apispec.json")
+    assert res.status_code == 200
+    spec = res.get_json()
+    assert "/api/v1/reports/get_report" in spec["paths"]
+    assert "/api/v1/projects" in spec["paths"]
+    # Auth schemes are advertised
+    assert "ApiKey" in spec["securityDefinitions"]
+    assert "Bearer" in spec["securityDefinitions"]
+
+
+def test_apidocs_ui_renders(client):
+    res = client.get("/apidocs/")
+    assert res.status_code == 200
+    # Swagger UI ships a static index that mentions swagger
+    assert b"swagger" in res.data.lower()


### PR DESCRIPTION
Closes the Specification roadmap entry. The API surface (especially the new `/api/v1/*` CI endpoints) now has a machine-readable spec and an interactive UI.

## What
- New runtime dep: `flasgger==0.9.7.1`.
- Swagger UI lives at [`/apidocs/`](http://localhost:5000/apidocs/), raw spec at [`/apispec.json`](http://localhost:5000/apispec.json).
- Two security definitions are declared, both backed by `DTRG_API_KEY`:
  - `ApiKey`: `X-DTRG-Key` header
  - `Bearer`: `Authorization: Bearer ...`
- All five routes get YAML docstrings:
  - `/api/v1/reports/get_report` and `/api/v1/projects` are fully documented (request body shape, all response codes including 401/502, security scheme reference).
  - `/`, `/reports/get_report`, `/projects/get_all` get short entries that flag them as form-only and point CI users at the API counterparts.
- README links to both endpoints from the CI usage section and marks the roadmap item done.

## Test plan
- [x] `pytest -q` → 67/67 (2 new tests verifying `/apispec.json` lists the API paths + auth schemes, and `/apidocs/` returns the UI page)
- [x] Local smoke: `/apispec.json` returns 200 with valid JSON, `/apidocs/` returns 200 HTML
- [ ] In the browser: try calls from `/apidocs/` against a real DT instance with and without `DTRG_API_KEY`

## Out of scope
- Hiding `/apidocs/` behind auth — discussed in plan, decision was to keep it public.
- Migrating to OpenAPI 3.x — flasgger emits 2.0 by default and that's enough for the use case; bumping is a separate change.