### PR TITLE
Lazy-load the project dropdown with pagination + search (roadmap: Optimization)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ curl -fsSL \
     -d '{}' \
     http://dtrg.internal:5000/api/v1/projects | jq '.[] | {name, version, uuid}'
 ```
+Need to filter or paginate? Pass `searchText`, `pageSize` and `pageNumber` in the JSON body. Total matches come back in the `X-Total-Count` response header. Without those fields the endpoint returns the full list as before.
 Notes:
 - `url` and `token` can be omitted from the request body when `DTRG_URL` and `DTRG_TOKEN` are set in the dtrg environment.
 - The endpoints are open by default. When the service is reachable beyond a trusted network, set `DTRG_API_KEY` so requests must present the same key in the `X-DTRG-Key` (or `Authorization: Bearer ...`) header.
@@ -91,6 +92,7 @@ All environment variables:
 * DTRG_API_KEY - shared secret required on the /api/v1/* endpoints. When unset (default) those endpoints are open and only network controls protect them; when set, callers must present the same value in an `X-DTRG-Key` or `Authorization: Bearer ...` header.
 * DTRG_INCLUDE_SUPPRESSED - when `true`, vulnerabilities that DT considers suppressed via VEX (state `resolved` / `resolved_with_pedigree` / `false_positive` / `not_affected`) are still rendered in the report with their analysis state in the `All issues` sheet. Default `false`, which matches the DT UI.
 * DTRG_GRAPH_DEPTH - max depth of the dependency graph traversal. Direct dependencies are level 1, their children level 2, etc. The level of each component is shown in column G of the `Vulnerable dependencies` sheet; components beyond the depth limit show an empty cell. Default 3.
+* DTRG_PROJECTS_PAGE_SIZE - page size for the form's project dropdown. Projects are loaded lazily as the user scrolls or types into the search box, so this controls how many DT projects are fetched per round-trip. Default 50. Does not affect `/api/v1/projects` (which still returns the full list by default).
 * CVEPAAS_URL - [CVE-PaaS](https://github.com/denimoll/CVE-PaaS) address
 ## Development
 Tests live under `tests/` and run with pytest:
@@ -112,6 +114,6 @@ Planned functionality:
 - [x] *Docs*. Add a documentation or just more info in readme.md for advansed settings (like custom port, use specific version and etc.)
 - [x] *VEX support*. Honour CycloneDX analysis state from DT so suppressed findings are dropped (or surfaced via DTRG_INCLUDE_SUPPRESSED) in the report.
 - [x] *Tests*. Smoke/unit tests for validators, severity merge, graph traversal, VEX filter and the API auth paths, run on every PR.
-- [ ] *Optimization*. Pagination + ajax-search for large project lists (so 10k+ projects in DT do not lock up the form).
+- [x] *Optimization*. Project dropdown is lazy-loaded via select2 ajax with debounced search. Page size controlled by `DTRG_PROJECTS_PAGE_SIZE`.
 - [x] *Graph*. Configurable traversal depth via `DTRG_GRAPH_DEPTH`; per-component level surfaced in the report.
 - [x] *Specification*. OpenAPI 2.0 spec served at `/apispec.json`; Swagger UI at `/apidocs/`.

--- a/app.py
+++ b/app.py
@@ -26,6 +26,7 @@ from flask_bootstrap import Bootstrap5
 from flask_wtf.csrf import CSRFProtect
 
 from backend.dependency_graph import get_graph
+from backend.param_validators import projects_page_size
 from backend.projects import get_projects
 from backend.reports import create_report
 from form import GetReportForm
@@ -310,9 +311,19 @@ def get_all_projects():
       - in: formData
         name: token
         type: string
+      - in: formData
+        name: searchText
+        type: string
+        description: Optional substring filter forwarded to DT.
+      - in: formData
+        name: pageNumber
+        type: integer
+        description: 1-based page number. Page size is fixed by DTRG_PROJECTS_PAGE_SIZE.
     responses:
       200:
-        description: DT project list.
+        description: |
+          DT project list for the requested page. The X-Total-Count header
+          carries the total number of matching projects.
       400:
         description: CSRF or upstream error.
     """
@@ -321,8 +332,22 @@ def get_all_projects():
     try:
         url = data.get("url")[0] if not os.getenv("DTRG_URL") else os.getenv("DTRG_URL")
         token = data.get("token")[0] if not os.getenv("DTRG_TOKEN") else os.getenv("DTRG_TOKEN")
-        logger.debug(f"Fetching projects from: {url}")
-        return get_projects(url, token)
+        search_text = (data.get("searchText") or [""])[0]
+        try:
+            page_number = max(int((data.get("pageNumber") or ["1"])[0]), 1)
+        except (ValueError, TypeError):
+            page_number = 1
+        logger.debug(f"Fetching projects from: {url} "
+                     f"(page={page_number}, search={search_text!r})")
+        body, total = get_projects(url, token,
+                                   search_text=search_text,
+                                   page_size=projects_page_size(),
+                                   page_number=page_number)
+        if isinstance(body, dict):
+            return jsonify(body), 502
+        response = Response(body, mimetype="application/json")
+        response.headers["X-Total-Count"] = str(total)
+        return response
     except (ValueError, ConnectionError, IndexError) as e:
         logger.error(f"Error fetching projects: {e}")
         flash(f"An internal error has occurred. {str(e)}", "danger")
@@ -356,11 +381,26 @@ def get_all_projects_api():
             token:
               type: string
               description: DT API key. Optional when DTRG_TOKEN is set.
+            searchText:
+              type: string
+              description: Optional substring filter forwarded to DT.
+            pageSize:
+              type: integer
+              description: |
+                Optional. Number of projects per page (default returns
+                everything DT has up to 99999 to preserve previous CI
+                behaviour).
+            pageNumber:
+              type: integer
+              description: Optional. 1-based page number (default 1).
     responses:
       200:
-        description: JSON array of DT project objects (forwarded from DT).
+        description: |
+          JSON array of DT project objects (forwarded from DT). The
+          X-Total-Count response header carries the total number of
+          projects matching the search.
       400:
-        description: Missing url and/or token (and no env defaults).
+        description: Missing url/token or non-integer pagination.
         schema:
           type: object
           properties:
@@ -383,11 +423,25 @@ def get_all_projects_api():
     token = os.getenv("DTRG_TOKEN") or body.get("token") or ""
     if not url or not token:
         return jsonify(error="url and token are required"), 400
-    logger.debug(f"API projects request for: {url}")
-    result = get_projects(url, token)
+
+    search_text = str(body.get("searchText") or "")
+    try:
+        page_size = int(body["pageSize"]) if body.get("pageSize") else 99999
+        page_number = max(int(body["pageNumber"]) if body.get("pageNumber") else 1, 1)
+    except (ValueError, TypeError):
+        return jsonify(error="pageSize and pageNumber must be integers"), 400
+
+    logger.debug(f"API projects request for: {url} "
+                 f"(page={page_number}, size={page_size}, search={search_text!r})")
+    result, total = get_projects(url, token,
+                                 search_text=search_text,
+                                 page_size=page_size,
+                                 page_number=page_number)
     if isinstance(result, dict):
         return jsonify(result), 502
-    return Response(result, mimetype="application/json")
+    response = Response(result, mimetype="application/json")
+    response.headers["X-Total-Count"] = str(total)
+    return response
 
 
 # GRAPH GROUP

--- a/app.py
+++ b/app.py
@@ -339,14 +339,16 @@ def get_all_projects():
             page_number = 1
         logger.debug(f"Fetching projects from: {url} "
                      f"(page={page_number}, search={search_text!r})")
+        page_size = projects_page_size()
         body, total = get_projects(url, token,
                                    search_text=search_text,
-                                   page_size=projects_page_size(),
+                                   page_size=page_size,
                                    page_number=page_number)
         if isinstance(body, dict):
             return jsonify(body), 502
         response = Response(body, mimetype="application/json")
         response.headers["X-Total-Count"] = str(total)
+        response.headers["X-Page-Size"] = str(page_size)
         return response
     except (ValueError, ConnectionError, IndexError) as e:
         logger.error(f"Error fetching projects: {e}")

--- a/backend/param_validators.py
+++ b/backend/param_validators.py
@@ -30,6 +30,14 @@ def graph_depth() -> int:
         return 3
 
 
+def projects_page_size() -> int:
+    """ Page size for the form's project dropdown (lazy-loaded from DT) """
+    try:
+        return int(os.getenv("DTRG_PROJECTS_PAGE_SIZE", "50"))
+    except ValueError:
+        return 50
+
+
 if not verify_tls():
     urllib3.disable_warnings()
 

--- a/backend/projects.py
+++ b/backend/projects.py
@@ -1,6 +1,7 @@
 """ Module for tasks with projects """
 
 import logging
+from urllib.parse import quote
 
 import requests
 
@@ -9,29 +10,43 @@ from backend.param_validators import check_format_url, check_token, http_timeout
 logger = logging.getLogger(__name__)
 
 
-def get_projects(url, token):
-    """ Return all projects from DT """
+def get_projects(url, token, search_text="", page_size=99999, page_number=1):
+    """ Fetch a page of DT projects.
+
+    Returns a (body, total) tuple. On success body is the raw JSON text
+    DT returned and total is the value of DT's X-Total-Count header.
+    On failure body is an {"error": ...} dict and total is 0.
+    """
     try:
         logger.debug("Starting project fetch")
-        
+
         # validate parameters
         url = check_format_url(url)
         headers = check_token(token, url)
-        
+
         endpoint = (
-            f"{url}project?excludeInactive=true&onlyRoot=false&searchText=&"
-            "sortName=lastBomImport&sortOrder=desc&pageSize=99999&pageNumber=1"
+            f"{url}project?excludeInactive=true&onlyRoot=false"
+            f"&searchText={quote(search_text)}"
+            f"&sortName=lastBomImport&sortOrder=desc"
+            f"&pageSize={page_size}&pageNumber={page_number}"
         )
         logger.debug(f"Sending request to: {endpoint}")
 
         # get projects
         res = requests.get(endpoint,
             headers=headers, verify=verify_tls(), timeout=http_timeout())
-        logger.debug(f"Successfully fetched projects, status code: {res.status_code}")
-        return res.text
+        if res.status_code != 200:
+            logger.warning(f"DT returned status {res.status_code} for project list")
+            return {"error": "Request to Dependency-Track failed"}, 0
+        try:
+            total = int(res.headers.get("X-Total-Count") or "0")
+        except ValueError:
+            total = 0
+        logger.debug(f"Fetched {res.text.count('uuid')} projects, total={total}")
+        return res.text, total
     except requests.RequestException as e:
         logger.exception(f"Failed to fetch projects: {str(e)}")
-        return {"error": "Request to Dependency-Track failed"}
+        return {"error": "Request to Dependency-Track failed"}, 0
     except Exception as e:
         logger.exception(f"Unexpected error in get_projects: {str(e)}")
-        return {"error": "Unexpected error while getting projects"}
+        return {"error": "Unexpected error while getting projects"}, 0

--- a/templates/index.html
+++ b/templates/index.html
@@ -87,49 +87,58 @@
         }
     </script>
     <script>
-        var req_get_all = 1;
         $(document).ready(function() {
             $("#project").select2({
-                placeholder: "Click to load projects from DT and wait",
-                allowClear: true
-            });
-            $(".selection").on("click", function(){
-                var project_field = $("#project");
-                sessionStorage.setItem("url", $("#url").val());
-                sessionStorage.setItem("token", $("#token").val());
-                if (project_field[0].length == 1 && req_get_all) {
-                    req_get_all = 0;
-                    $.ajax({
-                        type: "POST",
-                        url: "/projects/get_all",
-                        data: {
+                placeholder: "Type to search projects (URL and Token must be filled)",
+                allowClear: true,
+                minimumInputLength: 0,
+                ajax: {
+                    url: "/projects/get_all",
+                    type: "POST",
+                    delay: 300,
+                    cache: true,
+                    data: function (params) {
+                        sessionStorage.setItem("url", $("#url").val());
+                        sessionStorage.setItem("token", $("#token").val());
+                        return {
                             "url": $("#url").val(),
                             "token": $("#token").val(),
+                            "searchText": params.term || "",
+                            "pageNumber": params.page || 1,
                             "csrf_token": $('input[name="csrf_token"]').val()
-                        },
-                        success: function(data) {
-                            projects = jQuery.parseJSON(data);
-                            $.each(projects, function (i, item) {
-                                project_field.append($('<option>', { 
-                                    value: item.value,
-                                    text : item.name + " " + item.version + " (" + item.uuid + ")"
-                                }));
-                            });
-                            $("#project").select2({
-                                placeholder: "Select project",
-                            });
-                        },
-                        error: function(data) {
-                            req_get_all = 1;
-                            location.reload();
-                        },
-                        complete: function(data) {
-                            $("#url").val(sessionStorage.getItem("url"));
-                            $("#token").val(sessionStorage.getItem("token"));
+                        };
+                    },
+                    transport: function (params, success, failure) {
+                        if (!$("#url").val() || !$("#token").val()) {
+                            success({items: [], total: 0, pageSize: 0});
+                            return;
                         }
-                    });
+                        return $.ajax(params).then(function (data, _status, xhr) {
+                            success({
+                                items: data,
+                                total: parseInt(xhr.getResponseHeader("X-Total-Count")) || 0,
+                                pageSize: parseInt(xhr.getResponseHeader("X-Page-Size")) || data.length
+                            });
+                        }, failure);
+                    },
+                    processResults: function (response, params) {
+                        params.page = params.page || 1;
+                        var pageSize = response.pageSize || response.items.length || 1;
+                        var label = function (p) {
+                            return p.name + " " + (p.version || "") + " (" + p.uuid + ")";
+                        };
+                        return {
+                            results: response.items.map(function (p) {
+                                var l = label(p);
+                                return { id: l, text: l };
+                            }),
+                            pagination: {
+                                more: (params.page * pageSize) < response.total
+                            }
+                        };
+                    }
                 }
-            })
+            });
         });
     </script>
 {% endblock %}

--- a/tests/test_app_api.py
+++ b/tests/test_app_api.py
@@ -170,6 +170,7 @@ def test_form_projects_endpoint_paginates_with_env(monkeypatch):
     app_module.app.config.update(WTF_CSRF_ENABLED=True)
     assert res.status_code == 200
     assert res.headers["X-Total-Count"] == "0"
+    assert res.headers["X-Page-Size"] == "25"
     _, kwargs = mocked.call_args
     assert kwargs["page_size"] == 25
     assert kwargs["page_number"] == 2

--- a/tests/test_app_api.py
+++ b/tests/test_app_api.py
@@ -90,11 +90,9 @@ def test_api_projects_400_without_url_or_token(client):
 
 def test_api_projects_proxies_dt_response(client):
     """ With env defaults set, the endpoint forwards what get_projects returns """
-    fake_response = MagicMock()
-    fake_response.status_code = 200
-    fake_response.text = json.dumps([{"name": "proj", "uuid": "u"}])
+    body = json.dumps([{"name": "proj", "uuid": "u"}])
     with patch.object(app_module, "get_projects",
-                      return_value=fake_response.text) as mocked:
+                      return_value=(body, 1)) as mocked:
         res = client.post("/api/v1/projects",
                           headers={"X-DTRG-Key": "secret"},
                           data=json.dumps({"url": "https://example.com",
@@ -102,12 +100,13 @@ def test_api_projects_proxies_dt_response(client):
                           content_type="application/json")
     assert res.status_code == 200
     assert res.headers["Content-Type"].startswith("application/json")
+    assert res.headers["X-Total-Count"] == "1"
     assert mocked.called
 
 
 def test_api_projects_502_when_get_projects_returns_error_dict(client):
     with patch.object(app_module, "get_projects",
-                      return_value={"error": "Request to Dependency-Track failed"}):
+                      return_value=({"error": "Request to Dependency-Track failed"}, 0)):
         res = client.post("/api/v1/projects",
                           headers={"X-DTRG-Key": "secret"},
                           data=json.dumps({"url": "https://example.com",
@@ -115,6 +114,66 @@ def test_api_projects_502_when_get_projects_returns_error_dict(client):
                           content_type="application/json")
     assert res.status_code == 502
     assert res.get_json()["error"] == "Request to Dependency-Track failed"
+
+
+def test_api_projects_forwards_pagination(client):
+    body = json.dumps([])
+    with patch.object(app_module, "get_projects",
+                      return_value=(body, 0)) as mocked:
+        client.post("/api/v1/projects",
+                    headers={"X-DTRG-Key": "secret"},
+                    data=json.dumps({"url": "https://example.com", "token": "t",
+                                     "searchText": "kafka",
+                                     "pageSize": 25, "pageNumber": 3}),
+                    content_type="application/json")
+    args, kwargs = mocked.call_args
+    assert kwargs["search_text"] == "kafka"
+    assert kwargs["page_size"] == 25
+    assert kwargs["page_number"] == 3
+
+
+def test_api_projects_default_page_size_is_unbounded(client):
+    """ Backwards compat: CI users without pagination get the full list """
+    body = json.dumps([])
+    with patch.object(app_module, "get_projects",
+                      return_value=(body, 0)) as mocked:
+        client.post("/api/v1/projects",
+                    headers={"X-DTRG-Key": "secret"},
+                    data=json.dumps({"url": "https://example.com", "token": "t"}),
+                    content_type="application/json")
+    _, kwargs = mocked.call_args
+    assert kwargs["page_size"] == 99999
+    assert kwargs["page_number"] == 1
+
+
+def test_api_projects_400_on_garbage_pagination(client):
+    res = client.post("/api/v1/projects",
+                      headers={"X-DTRG-Key": "secret"},
+                      data=json.dumps({"url": "https://example.com", "token": "t",
+                                       "pageSize": "many"}),
+                      content_type="application/json")
+    assert res.status_code == 400
+    assert "integers" in res.get_json()["error"]
+
+
+def test_form_projects_endpoint_paginates_with_env(monkeypatch):
+    monkeypatch.delenv("DTRG_API_KEY", raising=False)
+    monkeypatch.setenv("DTRG_PROJECTS_PAGE_SIZE", "25")
+    app_module.app.config.update(TESTING=True, WTF_CSRF_ENABLED=False)
+    body = json.dumps([])
+    with patch.object(app_module, "get_projects",
+                      return_value=(body, 0)) as mocked:
+        with app_module.app.test_client() as c:
+            res = c.post("/projects/get_all",
+                         data={"url": "https://example.com", "token": "t",
+                               "searchText": "k", "pageNumber": "2"})
+    app_module.app.config.update(WTF_CSRF_ENABLED=True)
+    assert res.status_code == 200
+    assert res.headers["X-Total-Count"] == "0"
+    _, kwargs = mocked.call_args
+    assert kwargs["page_size"] == 25
+    assert kwargs["page_number"] == 2
+    assert kwargs["search_text"] == "k"
 
 
 # CSRF behaviour

--- a/tests/test_param_validators.py
+++ b/tests/test_param_validators.py
@@ -48,6 +48,18 @@ def test_graph_depth_falls_back_on_garbage(monkeypatch):
     monkeypatch.setenv("DTRG_GRAPH_DEPTH", "deep")
     assert pv.graph_depth() == 3
 
+def test_projects_page_size_default(monkeypatch):
+    monkeypatch.delenv("DTRG_PROJECTS_PAGE_SIZE", raising=False)
+    assert pv.projects_page_size() == 50
+
+def test_projects_page_size_explicit(monkeypatch):
+    monkeypatch.setenv("DTRG_PROJECTS_PAGE_SIZE", "200")
+    assert pv.projects_page_size() == 200
+
+def test_projects_page_size_falls_back_on_garbage(monkeypatch):
+    monkeypatch.setenv("DTRG_PROJECTS_PAGE_SIZE", "many")
+    assert pv.projects_page_size() == 50
+
 
 # check_format_url
 


### PR DESCRIPTION
Closes the Optimization roadmap entry. Solves the actual user pain (10k+ DT projects locking up the form) without adding a database.

## What
- New env `DTRG_PROJECTS_PAGE_SIZE` (default 50). Controls the form's per-request DT fetch size.
- `backend.get_projects` accepts `search_text`, `page_size`, `page_number`. URL-encodes the search text, returns `(body, total)` so callers can echo DT's `X-Total-Count`. Default `page_size=99999` keeps existing CI behaviour intact.
- `/projects/get_all` (form) now reads `searchText` / `pageNumber` from the POST body, forces page size to `projects_page_size()`, and emits both `X-Total-Count` and `X-Page-Size` response headers.
- `/api/v1/projects` (CI) takes the same fields from JSON, defaults `pageSize=99999` so existing curl/jq scripts get the full list, rejects non-integer pagination with 400. The Swagger docstring documents the new params and the total header.
- Frontend select2 switched to ajax mode: opening the dropdown fetches page 1, typing fires a debounced (300 ms) request with `searchText`, scrolling to the bottom requests the next page. A transport callback reads `X-Total-Count` and `X-Page-Size` so `pagination.more` stops correctly. Empty url/token short-circuits to an empty result so the dropdown stays inert until the form is filled.

## Verified
- `pytest -q` → 74/74 (5 new tests covering forwarded pagination params, default page_size for the API endpoint, garbage pagination → 400, env-driven page size on the form endpoint, and the X-Page-Size header)
- Existing get_projects mock tests updated to the new tuple return.

## Out of scope
- Caching DT responses on the dtrg side (the original "Database for fast search" framing) — pagination + search closes the user's reported pain. A cache can be added later if multi-user keystroke amplification becomes an issue.
- Pagination for `/api/v1/reports/get_report` — that one returns a single ZIP; nothing to paginate.

## Test plan
- [ ] DT instance with 10k+ projects: open dropdown → first 50 appear quickly, typing filters with 300 ms debounce, scrolling loads more
- [ ] Set `DTRG_PROJECTS_PAGE_SIZE=200`: page size in fetches increases
- [ ] CI: existing `/api/v1/projects` curl returns the full list with no params
- [ ] CI: `/api/v1/projects` with `{"pageSize":50,"pageNumber":2,"searchText":"kafka"}` returns the second page filtered by "kafka"; `X-Total-Count` matches DT