### PR TITLE
Fix VEX: pull authoritative analysis from the findings API

### DIFF
--- a/backend/reports.py
+++ b/backend/reports.py
@@ -102,6 +102,28 @@ def create_report(config, output_dir):
                 deps.get("ref"):deps.get("dependsOn")
             })
 
+        # The CycloneDX variant=withVulnerabilities does not always carry
+        # the analysis block (depends on DT version and how the VEX was
+        # imported). Pull the findings list separately - it is the source
+        # of truth for the audit state shown in the DT UI.
+        logger.info("Fetching VEX analysis from findings API")
+        res = requests.get(url+"finding/project/"+project+"?suppressed=true",
+                           headers=headers, verify=verify_tls(), timeout=http_timeout())
+        res.raise_for_status()
+        analysis_by_pair = {}
+        for finding in res.json() or []:
+            vuln_id = (finding.get("vulnerability") or {}).get("vulnId")
+            component_uuid = (finding.get("component") or {}).get("uuid")
+            analysis = finding.get("analysis") or {}
+            if vuln_id and component_uuid:
+                analysis_by_pair[(vuln_id, component_uuid)] = {
+                    "state": (analysis.get("state") or "").lower(),
+                    "justification": analysis.get("justification") or "",
+                    "is_suppressed": bool(analysis.get("isSuppressed")),
+                }
+        logger.info(f"Findings API returned analysis for "
+                    f"{len(analysis_by_pair)} (vuln, component) pairs")
+
         # get components
         res = requests.get(url+"component/project/"+project+
             "?searchText=&pageSize=99999&pageNumber=1",
@@ -133,14 +155,24 @@ def create_report(config, output_dir):
         suppressed_states = {"resolved", "resolved_with_pedigree",
                              "false_positive", "not_affected"}
         for vuln in vulnerabilities:
-            analysis = vuln.get("analysis") or {}
-            analysis_state = (analysis.get("state") or "").lower()
-            analysis_justification = analysis.get("justification") or ""
-            analysis_response = ", ".join(analysis.get("response") or [])
-            analysis_detail = analysis.get("detail") or ""
-            is_suppressed = analysis_state in suppressed_states
+            sbom_analysis = vuln.get("analysis") or {}
+            sbom_state = (sbom_analysis.get("state") or "").lower()
+            sbom_justification = sbom_analysis.get("justification") or ""
+            analysis_response = ", ".join(sbom_analysis.get("response") or [])
+            analysis_detail = sbom_analysis.get("detail") or ""
             for component in vuln.get("affects"):
                 vuln_id = vuln.get("id")
+                component_ref = component.get("ref")
+                # Findings API wins over the SBOM analysis block; SBOM is
+                # the fallback for response/detail (findings does not expose those).
+                finding_analysis = analysis_by_pair.get((vuln_id, component_ref), {})
+                analysis_state = finding_analysis.get("state") or sbom_state
+                analysis_justification = (finding_analysis.get("justification")
+                                          or sbom_justification)
+                is_suppressed = (
+                    finding_analysis.get("is_suppressed", False)
+                    or analysis_state in suppressed_states
+                )
                 vuln_word_link = RichText()
                 if "cve" in vuln_id.lower():
                     vuln_link = "https://nvd.nist.gov/vuln/detail/"+vuln_id

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -67,6 +67,8 @@ def _payloads_with_vex():
     return [
         # check_token probe — exact endswith /project (no trailing slash or uuid)
         (lambda u: u.endswith("/project"), []),
+        # findings API: empty in this fixture, all analysis carried in SBOM
+        ("finding/project", []),
         # SBOM with mixed analysis states
         ("bom/cyclonedx", {
             "vulnerabilities": [
@@ -182,6 +184,57 @@ def test_create_report_extracts_uuid_from_form_value(monkeypatch):
                       side_effect=_fake_dt_get(_payloads_with_vex())):
         report, _ = reports.create_report(cfg, td)
     assert isinstance(report, str)
+
+
+def _payloads_findings_only():
+    """ DT export without VEX in SBOM but a false-positive marked in the UI """
+    return [
+        (lambda u: u.endswith("/project"), []),
+        ("finding/project", [
+            {"vulnerability": {"vulnId": "CVE-2024-9999", "uuid": "v-uuid"},
+             "component": {"uuid": "c1", "name": "libA"},
+             "analysis": {"state": "FALSE_POSITIVE", "isSuppressed": True}},
+        ]),
+        ("bom/cyclonedx", {
+            "vulnerabilities": [
+                {"bom-ref": "v-uuid", "id": "CVE-2024-9999",
+                 "ratings": [{"severity": "high"}],
+                 "affects": [{"ref": "c1"}]},
+            ],
+            "dependencies": [{"ref": "c1", "dependsOn": []}],
+        }),
+        ("component/project", [
+            {"uuid": "c1", "name": "libA", "version": "1", "group": "",
+             "repositoryMeta": None},
+        ]),
+        ("/project/", {"name": "demo", "version": "1.0", "metrics": {},
+                       "directDependencies": "[]"}),
+    ]
+
+
+def test_findings_api_supplies_analysis_when_sbom_omits_it(monkeypatch):
+    """ The actual user-reported bug: a FP marked in DT must reach the report """
+    monkeypatch.setenv("DTRG_INCLUDE_SUPPRESSED", "true")
+    with tempfile.TemporaryDirectory() as td, \
+         patch.object(reports.requests, "get",
+                      side_effect=_fake_dt_get(_payloads_findings_only())):
+        report, components = reports.create_report(_config(), td)
+    assert isinstance(report, str)
+    vulns = [v for c in components.values() for v in c["vulnerabilities"]]
+    assert len(vulns) == 1
+    assert vulns[0]["analysis_state"] == "false_positive"
+    assert vulns[0]["is_suppressed"] is True
+
+
+def test_findings_api_filters_fp_by_default(monkeypatch):
+    """ Same setup but default mode drops the FP from the report """
+    monkeypatch.delenv("DTRG_INCLUDE_SUPPRESSED", raising=False)
+    with tempfile.TemporaryDirectory() as td, \
+         patch.object(reports.requests, "get",
+                      side_effect=_fake_dt_get(_payloads_findings_only())):
+        _, components = reports.create_report(_config(), td)
+    vulns = [v for c in components.values() for v in c["vulnerabilities"]]
+    assert vulns == []  # the only finding was a FP and it was filtered
 
 
 def test_create_report_returns_value_error_on_missing_url():


### PR DESCRIPTION
Closes the user-reported regression: marking a finding as "False positive" in the DT UI didn't reach the report — Analysis state column stayed empty and the finding was still rendered as live.

## Root cause
The CycloneDX export at `bom/cyclonedx/project/{uuid}?variant=withVulnerabilities` does **not always include** the per-vulnerability `analysis` block. Whether it appears depends on DT version and how the VEX was imported. Relying on it as the only source of truth was fragile.

## Fix
After the SBOM call, also hit `/api/v1/finding/project/{uuid}?suppressed=true` and build a `(vuln_id, component_uuid) → analysis` map. The findings API mirrors what the DT UI shows.

When attaching analysis to a per-component vulnerability:
- Findings entry wins over the SBOM analysis block
- SBOM remains the fallback for `response` / `detail` (findings API doesn't expose those fields)
- `is_suppressed` now also honours DT's explicit `isSuppressed` flag in addition to the state-set heuristic, so a finding manually suppressed without a state change is still filtered

## Cost
One extra HTTP call per report. Negligible against the per-CVE CVE-PaaS round trips that already dominate large reports.

## Test plan
- [x] `pytest -q` → 76/76 (2 new tests covering exactly the bug: SBOM with no analysis + findings API reporting `FALSE_POSITIVE` + `isSuppressed=true`)
- [ ] Real DT: mark a CVE as `False positive` in the UI, regenerate report:
  - Default mode: finding disappears from the report
  - `DTRG_INCLUDE_SUPPRESSED=true`: finding shown with `false_positive` in Analysis state column
- [ ] Real DT: confirm reports still work for projects without any VEX annotations (regression check)