### PR TITLE
2.0.0 release prep: healthcheck + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.0]
+
+### Breaking changes
+
+- TLS verification of outbound calls to DT and CVE-PaaS is now ON by default. Self-signed test instances must opt out via `DTRG_VERIFY_TLS=false`.
+- `DTRG_DEBUG=true` refuses to start when bound to a non-loopback address. Use `DTRG_HOST=127.0.0.1` (preferred) or set `DTRG_DEBUG_ALLOW_REMOTE=true` to confirm. The Werkzeug debugger is RCE-equivalent on a public bind.
+- The form endpoints `/reports/get_report` and `/projects/get_all` now enforce the CSRF token that the form had been rendering all along but the server was never validating. External scripts POSTing to these routes will get 400 unless they include `csrf_token`. CI integrations should use the new `/api/v1/*` endpoints instead.
+- The Docker image now runs as the non-root `dtrg` user. Mounted volumes that previously assumed root ownership need their permissions adjusted.
+- Existing CI scripts hitting `/projects/get_all` outside the form flow no longer work — that endpoint is for the browser. Use `POST /api/v1/projects` with JSON.
+- Long timeouts on the DT/CVE-PaaS HTTP client are gone. The default is now 120s (was 100/1000/10000 mixed). Override with `DTRG_HTTP_TIMEOUT` if a slow upstream needs more.
+- `backend.get_projects` Python signature changed (now returns a `(body, total)` tuple). External callers of the function need to unpack.
+- VEX-suppressed vulnerabilities (state `resolved` / `resolved_with_pedigree` / `false_positive` / `not_affected`) are now hidden from the report by default to match the DT UI. Set `DTRG_INCLUDE_SUPPRESSED=true` to keep them visible.
+- DT 4.x or newer is required (the new VEX path calls `/api/v1/finding/project/{uuid}`, present since DT 3.x).
+
+### Added
+
+- `POST /api/v1/reports/get_report` — JSON-friendly endpoint that returns a ZIP report. Designed for CI; gated by `DTRG_API_KEY` when set; always CSRF-exempt.
+- `POST /api/v1/projects` — JSON project listing for CI to resolve a UUID by name, with optional `searchText` / `pageSize` / `pageNumber` parameters and `X-Total-Count` response header.
+- `GET /health` — liveness/readiness probe returning `{"status":"ok","version":...}`. Used by the new Docker `HEALTHCHECK` directive.
+- OpenAPI 2.0 spec served at `/apispec.json`; Swagger UI at `/apidocs/` (powered by flasgger).
+- Lazy-loaded project dropdown: select2 now runs in ajax mode against `/projects/get_all` with debounced search (300 ms) and on-scroll pagination, so DT instances with thousands of projects no longer freeze the form.
+- VEX support: `analysis` state from the CycloneDX SBOM and `/api/v1/finding/project/{uuid}` is read on every report. The new `Analysis state` column in the `All issues` Excel sheet shows it; suppressed findings are filtered by default. `project_info.suppressedCount` is exposed in the docx Jinja context.
+- Configurable graph depth via `DTRG_GRAPH_DEPTH` (default 3). The new `Graph level` column in the `Vulnerable dependencies` Excel sheet shows the per-component depth (1 = direct, 2 = its child, etc.).
+- New env vars: `DTRG_API_KEY`, `DTRG_HOST`, `DTRG_DEBUG_ALLOW_REMOTE`, `DTRG_VERIFY_TLS`, `DTRG_HTTP_TIMEOUT`, `DTRG_SECRET_KEY`, `DTRG_INCLUDE_SUPPRESSED`, `DTRG_GRAPH_DEPTH`, `DTRG_PROJECTS_PAGE_SIZE`. All documented in the README.
+- Pytest test suite under `tests/` (~75 tests covering validators, severity merge, graph traversal, VEX filtering, API auth) running on every push/PR via `.github/workflows/tests.yml`.
+- `.dockerignore`.
+- Subresource Integrity (`integrity` + `crossorigin`) on the select2 CDN assets.
+
+### Changed
+
+- The Flask `SECRET_KEY` falls back to `os.urandom` only when `DTRG_SECRET_KEY` is not set. Setting it stably is required for multi-worker deploys and sessions surviving restarts.
+- Reports are now rendered into a per-request `tempfile.mkdtemp()` directory rather than fixed paths under `reports/`. Concurrent requests no longer race on shared file names.
+- The graph HTML moved from an inline f-string in `app.py` to a Jinja template at `templates/graph.html`.
+- Semgrep workflow migrated from the archived `returntocorp/semgrep-action` to `semgrep ci` inside the official `semgrep/semgrep` container.
+- The Docker image installs Python requirements before copying source so layer caching survives source edits.
+
+### Fixed
+
+- VEX `False positive` markings made in the DT UI now reach the report. The CycloneDX `withVulnerabilities` variant does not always carry the analysis block; the report now also reads `/api/v1/finding/project/{uuid}` as the authoritative source.
+- The dependency-graph traversal:
+  - Used to crash with `'str' object has no attribute 'get'` when every child UUID was already-visited or missing — the `dependencies` field on the parent kept its raw UUID list and `update_tree` choked on it.
+  - Cycles like `a → b → a` rendered `libA` twice; the visited set now seeds with direct-dep UUIDs.
+  - `KeyError` when DT returned dependency lists with missing references.
+- `get_severity` no longer crashes on `None` or unknown severity strings (previously a `KeyError` on something like `"none"`).
+- Project metadata access no longer crashes on projects with missing `metrics`, `dependencies`, or vulnerability `priority` — `None`-chains were guarded.
+- Project UUID parsed via regex so values without the `name version (uuid)` shape (e.g. a manually entered UUID via the API) no longer raise `IndexError`.
+- DT API calls now use `res.raise_for_status()` + `res.json()` so HTTP errors surface directly instead of being masked by a downstream JSON-decode error.
+- Two `f`-prefixed log strings that were not `f`-strings, so the placeholders never expanded.
+- Removed the dead `if not isinstance(...): raise <returned value>` defensive branches that pylint had to silence with `raising-bad-type` — the validators they guard already raise on failure.
+
+### Security
+
+- `DTRG_API_KEY` (optional) gates `/api/v1/*`. Compared with `hmac.compare_digest`. Authentication accepts both `X-DTRG-Key` and `Authorization: Bearer ...` headers.
+- CVE id flowing into the CVE-PaaS URL is restricted to canonical `CVE-YYYY-NNNN[N+]`, blocking URL-injection from a malformed upstream id.
+- DT API token is redacted before being logged at `DEBUG`.
+- Outbound HTTP timeouts unified at a sane default; the old 10000-second figure was DoS-shaped.
+- `os.chdir` removed from the report path; concurrent requests no longer race on the process working directory.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # dt-report-generator (dtrg) <img width="30" src="./static/icon.svg"/>
+
+> **Note:** version 2.0.0 brings several breaking changes (TLS verification on by default, CSRF enforced on form endpoints, Docker runs as non-root, new env vars). See [CHANGELOG.md](CHANGELOG.md) for the full list before upgrading.
 ## Main information
 Tool for create reports from [Dependency Track](https://dependencytrack.org/) in Word (.docx) and Excel (.xlsx) formats.\
 More information about tool and how to use it can be found in the articles on habr [1](https://habr.com/ru/articles/860536/), [2](https://habr.com/ru/articles/900276/) (rus).

--- a/app.py
+++ b/app.py
@@ -37,6 +37,8 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+__version__ = "2.0.0"
+
 app = Flask(__name__)
 app.config["SECRET_KEY"] = os.getenv("DTRG_SECRET_KEY") or secrets.token_hex(16)
 bootstrap = Bootstrap5(app)
@@ -102,6 +104,31 @@ def require_api_key(view):
                 return jsonify(error="unauthorized"), 401
         return view(*args, **kwargs)
     return wrapper
+
+
+# PROBES
+@app.route("/health", methods=["GET"])
+def health():
+    """Liveness/readiness probe.
+    ---
+    tags:
+      - probe
+    produces:
+      - application/json
+    responses:
+      200:
+        description: Service is up. Returns the running version.
+        schema:
+          type: object
+          properties:
+            status:
+              type: string
+              example: ok
+            version:
+              type: string
+              example: 2.0.0
+    """
+    return jsonify(status="ok", version=__version__)
 
 
 # INDEX PAGE

--- a/dockerfile
+++ b/dockerfile
@@ -11,5 +11,8 @@ COPY . /app
 RUN addgroup -S dtrg && adduser -S dtrg -G dtrg && chown -R dtrg:dtrg /app
 USER dtrg
 
+HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
+    CMD wget -qO- "http://localhost:${DTRG_PORT:-5000}/health" >/dev/null || exit 1
+
 ENTRYPOINT [ "python" ]
 CMD [ "app.py" ]

--- a/tests/test_app_api.py
+++ b/tests/test_app_api.py
@@ -22,6 +22,24 @@ def test_index_renders(client):
     assert b"Get report" in response.data
 
 
+def test_health_returns_status_and_version(client):
+    """ /health is the Docker/k8s probe target. Must work without auth. """
+    response = client.get("/health")
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["status"] == "ok"
+    assert body["version"] == app_module.__version__
+
+
+def test_health_does_not_require_api_key(monkeypatch):
+    """ Probe must succeed even when DTRG_API_KEY is set. """
+    monkeypatch.setenv("DTRG_API_KEY", "secret")
+    app_module.app.config.update(TESTING=True)
+    with app_module.app.test_client() as c:
+        response = c.get("/health")  # no key supplied
+    assert response.status_code == 200
+
+
 # require_api_key
 
 def test_api_reports_unauthorized_without_key(client):


### PR DESCRIPTION
Pre-release polish for the 2.0.0 cut.

## What
**`GET /health` probe**
- Returns `{"status":"ok","version":"2.0.0"}` without auth.
- Documented in OpenAPI under the `probe` tag.
- Dockerfile gets a `HEALTHCHECK` directive that hits the endpoint via busybox `wget`. The probe URL respects `DTRG_PORT` (defaults to 5000) so it still works when the operator overrides the port at runtime.

**`CHANGELOG.md`**
- Keep-A-Changelog format. The entire 2.0.0 set of changes (across the eight branches merged into `develop`) is summarised under `Breaking changes` / `Added` / `Changed` / `Fixed` / `Security`.
- README gets a bold note at the top pointing upgraders at the breaking-changes list so they don't get surprised by TLS-now-on, CSRF-now-enforced, Docker-now-non-root, and the new required env-var names.

## Test plan
- [x] `pytest -q` → 76/76 (2 new tests verifying `/health` returns version + works without `DTRG_API_KEY`)
- [x] Local smoke: `curl /health` returns the JSON
- [ ] `docker build .` and `docker inspect` shows the HEALTHCHECK directive
- [ ] Spin up the container; `docker ps` shows `(healthy)` after the start period