### PR TITLE
Plan post-2.0 work in the README roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,21 @@ Planned functionality:
 - [x] *Optimization*. Project dropdown is lazy-loaded via select2 ajax with debounced search. Page size controlled by `DTRG_PROJECTS_PAGE_SIZE`.
 - [x] *Graph*. Configurable traversal depth via `DTRG_GRAPH_DEPTH`; per-component level surfaced in the report.
 - [x] *Specification*. OpenAPI 2.0 spec served at `/apispec.json`; Swagger UI at `/apidocs/`.
+
+### CVE-PaaS collaboration
+- [ ] *Graceful degradation*. When CVE-PaaS is down or slow, finish the report without enrichment instead of failing the whole run.
+- [ ] *Batch endpoint*. Replace the per-CVE round-trip with a `POST /get_info_batch` call (requires CVE-PaaS-side change). Cuts report time from minutes to seconds on large projects.
+- [ ] *Cache*. Local SQLite cache for CVE-PaaS responses with configurable TTL, so repeat reports avoid the network hop.
+- [ ] *Wider enrichment*. Surface EPSS / KEV / vendor advisories from CVE-PaaS as report columns, not just `Priority`.
+- [ ] *CVE-PaaS auth*. Support an API-key header for the CVE-PaaS request when CVE-PaaS adopts authenticated access.
+
+### Future features
+- [ ] *Diff between project versions*. Show what vulnerabilities appeared, disappeared and changed between two versions of the same DT project.
+- [ ] *Multi-project reports*. One ZIP covering N projects at once for portfolio reviews.
+- [ ] *Severity overrides*. Per-component / per-CVE override rules (config file) so known false positives stay quiet.
+- [ ] *Rate limiting* on `/api/v1/*` to soften the impact of a runaway CI loop.
+
+### Pre-release polish carried over
+- [ ] *form.py env evaluation per request*. Read `DTRG_URL` / `DTRG_TOKEN` inside `__init__`, not at class definition time, so flipping the env at runtime takes effect without restart.
+- [ ] *CI matrix*. Run `pytest` against Python 3.11 and 3.13 in addition to 3.12.
+- [ ] *Multi-arch Docker*. Publish `linux/arm64` alongside `linux/amd64` for Apple Silicon and Raspberry Pi.


### PR DESCRIPTION
Pure docs change. Adds three roadmap subsections to capture what's next after the 2.0 cut.

## Sections

**CVE-PaaS collaboration** — биggest perf/value lever for 2.1. Five items, ordered by priority:
1. Graceful degradation (bug-fix-shaped — CVE-PaaS down should not kill the whole report)
2. Batch endpoint (cuts large-project report time from minutes to seconds; needs CVE-PaaS-side change)
3. Local SQLite cache for CVE-PaaS responses
4. Surface EPSS / KEV / vendor advisories as report columns
5. CVE-PaaS auth support when CVE-PaaS gets authenticated

**Future features** — diff between project versions (mentioned in the original VEX issue), multi-project reports, severity overrides, rate limiting on `/api/v1/*`.

**Pre-release polish carried over** — three small items noticed during 2.0 prep but not bundled into a PR:
- `form.py` reads env at class definition time
- CI tests only against Python 3.12
- Docker image is amd64-only

No code change.