### PR TITLE
Address CodeQL findings and fix the semgrep workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -3,9 +3,8 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-# This workflow file requires a free account on Semgrep.dev to
-# manage rules, file ignores, notifications, and more.
-#
+# Runs `semgrep scan --config=auto` against the public ruleset, so it does
+# not require a Semgrep.dev account or SEMGREP_APP_TOKEN.
 # See https://semgrep.dev/docs
 
 name: Semgrep
@@ -37,14 +36,15 @@ jobs:
       # Checkout project source
       - uses: actions/checkout@v4
 
-      # Scan code using project's configuration on https://semgrep.dev/manage
-      - run: semgrep ci --sarif --output=semgrep.sarif
-        env:
-          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+      # Scan with the public ruleset; always emit SARIF so the upload step
+      # has a file even when semgrep returns a non-zero exit code on
+      # findings.
+      - name: Run semgrep
+        run: semgrep scan --config=auto --sarif --output=semgrep.sarif --error || true
 
       # Upload SARIF file generated in previous step
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: semgrep.sarif
-        if: always()
+        if: always() && hashFiles('semgrep.sarif') != ''

--- a/app.py
+++ b/app.py
@@ -24,6 +24,7 @@ from flask import (
 from flasgger import Swagger
 from flask_bootstrap import Bootstrap5
 from flask_wtf.csrf import CSRFProtect
+from werkzeug.utils import secure_filename
 
 from backend.dependency_graph import get_graph
 from backend.param_validators import projects_page_size
@@ -163,7 +164,7 @@ def create_zip(output_dir, with_graph=False):
         return zip_path
     except OSError as e:
         logger.error(f"Error while creating ZIP: {e}")
-        flash(str(e), "danger")
+        flash("Failed to build report archive.", "danger")
         return None
 
 def _redact(form_data):
@@ -174,6 +175,23 @@ def _redact(form_data):
 def _new_output_dir():
     """ Create a unique output directory for a single report request """
     return tempfile.mkdtemp(prefix="dtrg-")
+
+def _safe_download_name(report):
+    """ Sanitize the report-name string before it lands in Content-Disposition.
+
+    `report` is built from the DT project name + version + date. The DT
+    project name is operator-controlled but flows from an external system,
+    so we run it through werkzeug's secure_filename to drop any path
+    separators or odd unicode before sending it as a header.
+    """
+    safe = secure_filename(f"{report}.zip")
+    return safe or "report.zip"
+
+# Generic message returned to clients when report generation fails. The
+# actual exception is logged; we do not surface its str() to keep
+# CodeQL py/stack-trace-exposure happy and to avoid accidental leaks
+# when validators evolve to embed contextual data.
+_GENERIC_REPORT_FAILURE = "Report generation failed. Check server logs for details."
 
 def _build_report(config, output_dir):
     """ Run create_report + graph + zip and return (zip_path, name_or_error) """
@@ -234,9 +252,10 @@ def get_report():
     zip_path, report = _build_report(data, output_dir)
     if zip_path:
         logger.info("Report generation successful. Sending ZIP file")
-        return send_file(zip_path, as_attachment=True, download_name=f"{report}.zip")
+        return send_file(zip_path, as_attachment=True,
+                         download_name=_safe_download_name(report))
     logger.error(f"Report generation failed: {report}")
-    flash(str(report), "danger")
+    flash(_GENERIC_REPORT_FAILURE, "danger")
     return redirect(url_for("index"))
 
 @app.route("/api/v1/reports/get_report", methods=["POST"])
@@ -311,9 +330,10 @@ def get_report_api():
     zip_path, report = _build_report(config, output_dir)
     if not zip_path:
         logger.error(f"API report generation failed: {report}")
-        return jsonify(error=str(report)), 400
+        return jsonify(error=_GENERIC_REPORT_FAILURE), 400
     return send_file(zip_path, as_attachment=True,
-                     download_name=f"{report}.zip", mimetype="application/zip")
+                     download_name=_safe_download_name(report),
+                     mimetype="application/zip")
 
 
 # PROJECTS GROUP
@@ -379,8 +399,8 @@ def get_all_projects():
         return response
     except (ValueError, ConnectionError, IndexError) as e:
         logger.error(f"Error fetching projects: {e}")
-        flash(f"An internal error has occurred. {str(e)}", "danger")
-        return jsonify(error_msg=f"An internal error has occurred. {str(e)}"), 400
+        flash("An internal error has occurred while fetching projects.", "danger")
+        return jsonify(error_msg="An internal error has occurred."), 400
 
 @app.route("/api/v1/projects", methods=["POST"])
 @csrf.exempt


### PR DESCRIPTION
Pre-2.0-release CI cleanup. Three issues, one PR. Targets `develop`; merge before re-running the develop → main PR.

## CodeQL findings

### Line 314 — Information exposure through an exception
**TRUE POSITIVE in form, low impact today.** The `report` value at this point is a `ValueError` or `ConnectionError` whose messages come from our own validators (`"URL not valid"`, `"Token not set"`, `"Failed to connect to server"`, etc.) — none of them embed paths, stack traces or other internal state. **But** baking "we promise our exceptions are safe" into the response surface is fragile: any future `raise ValueError(f"... {internal_url} ...")` would silently leak. Fixed by returning a fixed `"Report generation failed. Check server logs for details."` string while still logging the full exception at ERROR. Same treatment for:
- `flash(str(report), "danger")` in the form `/reports/get_report`
- `flash(str(e), "danger")` in `create_zip`
- `flash(... str(e) ...)` and `jsonify(error_msg=... str(e) ...)` in `/projects/get_all`

### Line 315 — Uncontrolled data used in path expression
**FALSE POSITIVE in semantics, TRUE POSITIVE as defense-in-depth.** `download_name` is the `Content-Disposition` header value — Flask never uses it as a server-side file path. So no actual path-traversal vector exists here. But `report` is built from the DT project name, which an operator can set to anything (slashes, `..`, NUL, weird unicode). Browsers handle some of this awkwardly, and CodeQL has a point about not trusting the value blindly. Fixed by running the filename through `werkzeug.utils.secure_filename` before it ships in the header. Applied at both `send_file` sites (form + API).

## Semgrep workflow

Two problems:
- `github/codeql-action/upload-sarif@v3` triggers a December-2026 deprecation warning. Bumped to `@v4`.
- `semgrep ci --sarif --output=semgrep.sarif` failed with `Path does not exist: semgrep.sarif` because `semgrep ci` exits early when `SEMGREP_APP_TOKEN` is missing/expired and never writes the file, leaving the upload step stranded.

Switched to `semgrep scan --config=auto`. No token required (uses the public ruleset), reliably writes the sarif. Added `|| true` so a non-zero exit on findings still leaves the file in place, and guarded the upload step with `hashFiles('semgrep.sarif') != ''` for belt-and-braces.

## Test plan
- [x] `pytest -q` → 78/78 passing locally
- [ ] Re-run the develop → main PR; CodeQL alerts on lines 314/315 should clear
- [ ] Semgrep workflow now produces a SARIF and the upload step succeeds
- [ ] Manual report generation: form path still flashes a useful (now generic) error on bad URL/token, API path still returns 400 JSON