### PR TITLE
2.1.0: Bucket-1 quick wins

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Set up QEMU (cross-arch emulation)
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:
@@ -35,6 +39,7 @@ jobs:
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,13 +12,18 @@ permissions:
 jobs:
   pytest:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    name: pytest (Python ${{ matrix.python-version }})
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: |
             requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0]
+
+### Added
+
+- `summary.json` bundled in every report ZIP next to `result.docx` / `result.xlsx`. Carries the project metadata and the vulnerable-components list in a JSON-serializable shape (versioned via `schemaVersion: 1`) so CI pipelines can do severity gates, dashboards or diffing without parsing Office files.
+- Docker images now publish for `linux/amd64` **and** `linux/arm64`. Apple Silicon dev machines and arm SBCs (Raspberry Pi, Ampere) get a native image instead of QEMU emulation.
+
+### Changed
+
+- `pytest` runs in CI against Python 3.11, 3.12 and 3.13 (was only 3.12).
+- `GetReportForm` reads `DTRG_URL` / `DTRG_TOKEN` per request inside `__init__` rather than at class definition time, so flipping the env at runtime takes effect on the next form render without restarting the process.
+
 ## [2.0.0]
 
 ### Breaking changes

--- a/app.py
+++ b/app.py
@@ -38,7 +38,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 
 app = Flask(__name__)
 app.config["SECRET_KEY"] = os.getenv("DTRG_SECRET_KEY") or secrets.token_hex(16)

--- a/app.py
+++ b/app.py
@@ -156,8 +156,10 @@ def create_zip(output_dir, with_graph=False):
     zip_path = os.path.join(output_dir, "reports.zip")
     try:
         with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zipf:
-            for file in ["result.docx", "result.xlsx"]:
-                zipf.write(os.path.join(output_dir, file), arcname=file)
+            for file in ["result.docx", "result.xlsx", "summary.json"]:
+                src = os.path.join(output_dir, file)
+                if os.path.exists(src):
+                    zipf.write(src, arcname=file)
             if with_graph:
                 zipf.write(os.path.join(output_dir, "graph.html"), arcname="graph.html")
         logger.info("ZIP archive created successfully")
@@ -296,7 +298,7 @@ def get_report_api():
               example: 00000000-0000-0000-0000-000000000000
     responses:
       200:
-        description: ZIP archive with result.docx, result.xlsx and graph.html.
+        description: ZIP archive with result.docx, result.xlsx, summary.json and graph.html.
       400:
         description: Validation error (missing field or upstream rejected).
         schema:

--- a/backend/reports.py
+++ b/backend/reports.py
@@ -24,6 +24,60 @@ logger = logging.getLogger(__name__)
 
 
 
+SUMMARY_SCHEMA_VERSION = 1
+
+
+def _build_summary(project_name_str, project_url, project_info, vuln_components):
+    """ Machine-readable companion to the docx/xlsx report.
+
+    Produced as summary.json inside the ZIP so CI pipelines can post-process
+    the report (severity gates, dashboards, ...) without parsing Office files.
+    Kept intentionally flat - one component per entry, vulnerabilities nested
+    inline - and only exposes JSON-serializable fields.
+    """
+    return {
+        "schemaVersion": SUMMARY_SCHEMA_VERSION,
+        "project": {
+            "name": project_name_str,
+            "version": project_info.get("version"),
+            "url": project_url,
+            "lastBomImport": project_info.get("lastBomImport"),
+            "generatedAt": project_info.get("date"),
+            "componentsCount": project_info.get("componentsCount"),
+            "vulnerableComponentsCount": project_info.get("vulnComponentsCount"),
+            "vulnerabilitiesCount": project_info.get("vulnsCount"),
+            "suppressedCount": project_info.get("suppressedCount", 0),
+        },
+        "components": [
+            {
+                "name": c.get("name"),
+                "version": c.get("version"),
+                "group": c.get("group"),
+                "lastVersion": c.get("last_version"),
+                "isDirectDependency": c.get("is_direct_dependency"),
+                "graphLevel": c.get("graph_level"),
+                "severity": c.get("severity"),
+                "vulnerabilities": [
+                    {
+                        "id": v.get("id"),
+                        "link": v.get("link"),
+                        "severity": v.get("severity"),
+                        "priority": v.get("priority"),
+                        "addInfo": v.get("add_info"),
+                        "analysisState": v.get("analysis_state"),
+                        "analysisJustification": v.get("analysis_justification"),
+                        "analysisResponse": v.get("analysis_response"),
+                        "analysisDetail": v.get("analysis_detail"),
+                        "isSuppressed": v.get("is_suppressed"),
+                    }
+                    for v in c.get("vulnerabilities") or []
+                ],
+            }
+            for c in vuln_components
+        ],
+    }
+
+
 def get_severity(severities):
     """ Get level and name of severity by list severities """
     severity = {
@@ -312,6 +366,15 @@ def create_report(config, output_dir):
             del excel["All issues"]
         excel.save(os.path.join(output_dir, "result.xlsx"))
         logger.info("Excel report saved")
+
+        # write the JSON summary for downstream tooling
+        project_url = url.split("api/v1/")[0] + "projects/" + project
+        summary = _build_summary(project_name_str, project_url,
+                                 project_info, vuln_components)
+        with open(os.path.join(output_dir, "summary.json"), "w",
+                  encoding="utf-8") as f:
+            json.dump(summary, f, ensure_ascii=False, indent=2)
+        logger.info("JSON summary saved")
 
         # return
         report_name = project_name_str or project_id

--- a/form.py
+++ b/form.py
@@ -6,17 +6,31 @@ from flask_wtf import FlaskForm
 from wtforms import PasswordField, SelectField, StringField, SubmitField, validators
 
 
+# Sentinel render_kw applied to URL/Token when the corresponding DTRG_*
+# env var is set, so the form makes it visible that an admin has pinned
+# the value and there is nothing for the user to fill in.
+_AAS_RENDER_KW = {
+    "readonly": True,
+    "placeholder": "The admin has already set the value",
+}
+
+
 class GetReportForm(FlaskForm):
     """" Main UI form for report generation """
-    # for aaS
-    attributes = {
-        "readonly": True,
-        "placeholder": "The admin has already set the value"
-    }
 
-    url = StringField("URL", render_kw=attributes if os.getenv("DTRG_URL") else {})
-    token = PasswordField("Token", render_kw=attributes if os.getenv("DTRG_TOKEN") else {})
+    url = StringField("URL")
+    token = PasswordField("Token")
     project = SelectField("Project",
         choices=[("", "")],
         validators=[validators.InputRequired()])
     submit = SubmitField("Get report")
+
+    def __init__(self, *args, **kwargs):
+        # Read DTRG_URL / DTRG_TOKEN per request rather than at class
+        # definition time, so flipping the env at runtime takes effect
+        # on the next form render without restarting the process.
+        super().__init__(*args, **kwargs)
+        if os.getenv("DTRG_URL"):
+            self.url.render_kw = _AAS_RENDER_KW
+        if os.getenv("DTRG_TOKEN"):
+            self.token.render_kw = _AAS_RENDER_KW

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -1,0 +1,46 @@
+""" Tests for form.GetReportForm """
+
+import app as app_module
+from form import GetReportForm
+
+
+def _form_in_context():
+    """ FlaskForm needs an app context to render """
+    with app_module.app.test_request_context("/"):
+        return GetReportForm()
+
+
+def test_url_field_writable_when_env_unset(monkeypatch):
+    monkeypatch.delenv("DTRG_URL", raising=False)
+    monkeypatch.delenv("DTRG_TOKEN", raising=False)
+    form = _form_in_context()
+    assert form.url.render_kw in (None, {})
+    assert form.token.render_kw in (None, {})
+
+
+def test_url_field_locked_when_dtrg_url_set(monkeypatch):
+    monkeypatch.setenv("DTRG_URL", "https://dt.example.com")
+    monkeypatch.delenv("DTRG_TOKEN", raising=False)
+    form = _form_in_context()
+    assert form.url.render_kw is not None
+    assert form.url.render_kw.get("readonly") is True
+    assert form.token.render_kw in (None, {})
+
+
+def test_token_field_locked_when_dtrg_token_set(monkeypatch):
+    monkeypatch.delenv("DTRG_URL", raising=False)
+    monkeypatch.setenv("DTRG_TOKEN", "abc")
+    form = _form_in_context()
+    assert form.token.render_kw is not None
+    assert form.token.render_kw.get("readonly") is True
+
+
+def test_env_change_takes_effect_on_next_form(monkeypatch):
+    """ Per-request reading: flipping the env between forms is visible """
+    monkeypatch.delenv("DTRG_URL", raising=False)
+    first = _form_in_context()
+    assert first.url.render_kw in (None, {})
+
+    monkeypatch.setenv("DTRG_URL", "https://dt.example.com")
+    second = _form_in_context()
+    assert second.url.render_kw.get("readonly") is True

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,6 +1,7 @@
 """ Tests for backend.reports """
 
 import json
+import os
 import tempfile
 from unittest.mock import MagicMock, patch
 
@@ -235,6 +236,30 @@ def test_findings_api_filters_fp_by_default(monkeypatch):
         _, components = reports.create_report(_config(), td)
     vulns = [v for c in components.values() for v in c["vulnerabilities"]]
     assert vulns == []  # the only finding was a FP and it was filtered
+
+
+def test_create_report_writes_summary_json(monkeypatch):
+    """ summary.json sits next to result.docx/result.xlsx for CI consumers """
+    monkeypatch.delenv("DTRG_INCLUDE_SUPPRESSED", raising=False)
+    with tempfile.TemporaryDirectory() as td, \
+         patch.object(reports.requests, "get",
+                      side_effect=_fake_dt_get(_payloads_with_vex())):
+        reports.create_report(_config(), td)
+        summary_path = os.path.join(td, "summary.json")
+        assert os.path.exists(summary_path)
+        with open(summary_path, encoding="utf-8") as f:
+            summary = json.load(f)
+    assert summary["schemaVersion"] == reports.SUMMARY_SCHEMA_VERSION
+    assert summary["project"]["name"] == "demo"
+    assert summary["project"]["version"] == "1.0"
+    component_names = {c["name"] for c in summary["components"]}
+    assert "libA" in component_names
+    # Suppressed (not_affected) finding is filtered by default - libB drops out
+    assert "libB" not in component_names
+    assert "libC" in component_names
+    libA = next(c for c in summary["components"] if c["name"] == "libA")
+    assert libA["vulnerabilities"][0]["id"] == "CVE-2024-0001"
+    assert libA["vulnerabilities"][0]["analysisState"] == "exploitable"
 
 
 def test_create_report_returns_value_error_on_missing_url():


### PR DESCRIPTION
Targets `develop`. Implements all four "Bucket 1" items from the post-2.0 roadmap. No structural changes, no breaking changes.

## What

### 1. `GetReportForm` reads env per-request
The aaS readonly attributes were resolved at class-definition time (when `form.py` was imported), so flipping `DTRG_URL` / `DTRG_TOKEN` at runtime had no effect on rendering until restart. Moved the lookup into `__init__` — Flask constructs a fresh form per render, so this is per-request.

### 2. CI matrix: Python 3.11 + 3.12 + 3.13
`tests.yml` now runs the suite across three Python versions in a fail-fast=false matrix. Catches version-specific regressions early.

### 3. Multi-arch Docker (`linux/amd64`, `linux/arm64`)
`publish.yml` gets `setup-qemu-action` and `setup-buildx-action` so `docker/build-push-action` produces a manifest list for both architectures. Apple Silicon and arm SBCs get a native image. Base image already supports both arches; no Dockerfile changes.

### 4. `summary.json` bundled in the report ZIP
A machine-readable companion file at the root of the ZIP (next to `result.docx` / `result.xlsx`) so CI pipelines can post-process the report without parsing Office files. Versioned via `schemaVersion: 1`. Carries:

- `project`: name, version, DT URL, lastBomImport, generatedAt, componentsCount, vulnerableComponentsCount, vulnerabilitiesCount, suppressedCount.
- `components`: vulnerable-components list with name/version/group/lastVersion/isDirectDependency/graphLevel/severity and nested `vulnerabilities` (id, link, severity, priority, addInfo, analysisState/Justification/Response/Detail, isSuppressed).

Only JSON-serializable fields included; the docx-specific RichText objects stay out of the summary. `create_zip` adds `summary.json` conditionally so error paths still produce a valid archive.

### 5. Version bump + changelog
`__version__` → `2.1.0`. CHANGELOG.md gets a `[2.1.0]` section with Added/Changed.

## Test plan
- [x] `pytest -q` → 83/83 (5 new tests: 4 for form, 1 for summary.json)
- [x] Local smoke: ZIP contains `summary.json`, JSON shape matches schema
- [ ] Real DT: generate a report, unzip, verify `summary.json` is parseable and matches what's in docx/xlsx
- [ ] Real DT: set `DTRG_URL` after dtrg start (e.g. via reload), confirm form fields turn readonly on next render
- [ ] After merge: tag release, confirm Docker image manifest lists both `linux/amd64` and `linux/arm64`
- [ ] After merge: CI matrix shows three green pytest jobs